### PR TITLE
feat(api): add immediate hop message/ack protocol conformance metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.1.1"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2145,7 +2145,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 members = ["api"]
 
 [workspace.package]
-version = "1.1.1"
+version = "1.2.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
 repository = "https://github.com/hoprnet/hopr-api"

--- a/api/src/graph/costs.rs
+++ b/api/src/graph/costs.rs
@@ -1,7 +1,8 @@
 use std::sync::Arc;
 
 use super::traits::{
-    CostFn, EdgeLinkObservable, EdgeNetworkObservableRead, EdgeObservableRead, EdgeProtocolObservable,
+    CostFn, EdgeImmediateProtocolObservable, EdgeLinkObservable, EdgeNetworkObservableRead, EdgeObservableRead,
+    EdgeProtocolObservable,
 };
 
 /// A shared cost function accepting `(current_cost, edge_weight, path_index) -> new_cost`.
@@ -10,6 +11,19 @@ pub type BasicCostFn<C, W> = Arc<dyn Fn(C, &W, usize) -> C + Send + Sync>;
 /// Scales cost by score when probes exist, otherwise applies the penalizing multiplier.
 fn score_or_penalize(cost: f64, score: f64, penalty: f64) -> f64 {
     if score > 0.0 { cost * score } else { cost * penalty }
+}
+
+/// Applies the ack rate as a cost modifier for immediate edges.
+///
+/// When the ack rate is available and below `min_ack_rate`, the edge is rejected.
+/// When available and above the threshold, the cost is scaled by the ack rate.
+/// When unavailable (insufficient data), the penalty multiplier is applied.
+fn apply_ack_rate(ack_rate: Option<f64>, cost: f64, min_ack_rate: f64, penalty: f64) -> f64 {
+    match ack_rate {
+        Some(rate) if rate < min_ack_rate => -cost,
+        Some(rate) => cost * rate,
+        None => cost * penalty,
+    }
 }
 
 /// Checks for intermediate capacity and applies score-or-penalize, rejecting if absent.
@@ -82,14 +96,19 @@ where
     /// `penalty` is clamped to `[0.0, 1.0]` — the penalizing multiplier applied
     /// to edges lacking probe-based quality observations.
     ///
+    /// `min_ack_rate` is clamped to `[0.0, 1.0]` — the minimum acceptable message
+    /// acknowledgment rate for the immediate peer. Edges with an ack rate below this
+    /// threshold are rejected.
+    ///
     /// - **First edge**: requires connectivity and intermediate capacity; scores by the better of
-    ///   immediate/intermediate observations.
+    ///   immediate/intermediate observations, then applies the ack rate modifier.
     /// - **Last edge**: accepts intermediate capacity or immediate connectivity; penalizes when neither is available
     ///   (last hop is not monetized). Takes priority over first edge when `length == 1`.
     /// - **Intermediate edges**: require capacity; penalize when unprobed.
-    pub fn forward(length: std::num::NonZeroUsize, penalty: f64) -> Self {
+    pub fn forward(length: std::num::NonZeroUsize, penalty: f64, min_ack_rate: f64) -> Self {
         let length = length.get();
         let penalty = penalty.clamp(0.0, 1.0);
+        let min_ack_rate = min_ack_rate.clamp(0.0, 1.0);
         Self {
             initial: 1.0,
             min: Some(0.0),
@@ -119,7 +138,8 @@ where
                         && let Some(intermediate) = observation.intermediate_qos()
                         && intermediate.capacity().is_some()
                     {
-                        return cost * immediate.score().max(intermediate.score());
+                        let base = cost * immediate.score().max(intermediate.score());
+                        return apply_ack_rate(immediate.ack_rate(), base, min_ack_rate, penalty);
                     }
                     -cost
                 }
@@ -133,16 +153,21 @@ where
     /// `penalty` is clamped to `[0.0, 1.0]` — the penalizing multiplier applied
     /// to edges lacking probe-based quality observations.
     ///
+    /// `min_ack_rate` is clamped to `[0.0, 1.0]` — the minimum acceptable message
+    /// acknowledgment rate for the immediate peer. Edges with an ack rate below this
+    /// threshold are rejected.
+    ///
     /// Used when the planner (`me`) constructs the return path `dest -> relay -> me`.
     /// The first edge (`dest -> relay`) has relaxed requirements compared to
     /// [`EdgeCostFn::forward`] because the planner lacks intermediate QoS data.
     ///
-    /// - **Last edge** (relay -> me): requires immediate connectivity.
+    /// - **Last edge** (relay -> me): requires immediate connectivity; applies the ack rate modifier.
     /// - **All other edges**: require intermediate capacity; the `penalty` penalizing multiplier is applied when probe
     ///   scores are absent.
-    pub fn returning(length: std::num::NonZeroUsize, penalty: f64) -> Self {
+    pub fn returning(length: std::num::NonZeroUsize, penalty: f64, min_ack_rate: f64) -> Self {
         let length = length.get();
         let penalty = penalty.clamp(0.0, 1.0);
+        let min_ack_rate = min_ack_rate.clamp(0.0, 1.0);
         Self {
             initial: 1.0,
             min: Some(0.0),
@@ -152,7 +177,8 @@ where
                     if let Some(immediate) = observation.immediate_qos()
                         && immediate.is_connected()
                     {
-                        return score_or_penalize(cost, immediate.score(), penalty);
+                        let base = score_or_penalize(cost, immediate.score(), penalty);
+                        return apply_ack_rate(immediate.ack_rate(), base, min_ack_rate, penalty);
                     }
                     -cost
                 }
@@ -167,11 +193,16 @@ where
     /// `penalty` is clamped to `[0.0, 1.0]` — the penalizing multiplier applied
     /// to edges lacking probe-based quality observations.
     ///
+    /// `min_ack_rate` is clamped to `[0.0, 1.0]` — the minimum acceptable message
+    /// acknowledgment rate for the immediate peer. Edges with an ack rate below this
+    /// threshold are rejected.
+    ///
     /// - **First edge**: same as [`EdgeCostFn::forward`].
     /// - **All other edges**: require capacity; the `penalty` penalizing multiplier is applied when probe scores are
     ///   absent.
-    pub fn forward_without_self_loopback(penalty: f64) -> Self {
+    pub fn forward_without_self_loopback(penalty: f64, min_ack_rate: f64) -> Self {
         let penalty = penalty.clamp(0.0, 1.0);
+        let min_ack_rate = min_ack_rate.clamp(0.0, 1.0);
         Self {
             initial: 1.0,
             min: Some(0.0),
@@ -183,7 +214,8 @@ where
                         && let Some(intermediate) = observation.intermediate_qos()
                         && intermediate.capacity().is_some()
                     {
-                        return cost * immediate.score().max(intermediate.score());
+                        let base = cost * immediate.score().max(intermediate.score());
+                        return apply_ack_rate(immediate.ack_rate(), base, min_ack_rate, penalty);
                     }
                     -cost
                 }
@@ -208,11 +240,12 @@ mod tests {
 
     use super::*;
     use crate::graph::traits::{
-        EdgeLinkObservable, EdgeNetworkObservableRead, EdgeObservableRead, EdgeProtocolObservable,
-        EdgeTransportMeasurement,
+        EdgeImmediateProtocolObservable, EdgeLinkObservable, EdgeNetworkObservableRead, EdgeObservableRead,
+        EdgeProtocolObservable, EdgeTransportMeasurement,
     };
 
     const TEST_PENALTY: f64 = 0.5;
+    const TEST_MIN_ACK_RATE: f64 = 0.1;
 
     // ── Serializable stub types (pure value holders) ─────────────────────
 
@@ -221,11 +254,18 @@ mod tests {
     struct StubImmediate {
         connected: bool,
         score: f64,
+        ack_rate: Option<f64>,
     }
 
     impl EdgeNetworkObservableRead for StubImmediate {
         fn is_connected(&self) -> bool {
             self.connected
+        }
+    }
+
+    impl EdgeImmediateProtocolObservable for StubImmediate {
+        fn ack_rate(&self) -> Option<f64> {
+            self.ack_rate
         }
     }
 
@@ -318,6 +358,7 @@ mod tests {
             immediate: Some(StubImmediate {
                 connected: true,
                 score: 0.95,
+                ack_rate: Some(0.9),
             }),
             intermediate: Some(StubIntermediate {
                 capacity: Some(1000),
@@ -332,6 +373,7 @@ mod tests {
             immediate: Some(StubImmediate {
                 connected: true,
                 score: 0.95,
+                ack_rate: Some(0.9),
             }),
             intermediate: None,
         }
@@ -382,6 +424,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         #[derive(serde::Serialize)]
         struct Invariants {
@@ -402,6 +445,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
@@ -421,6 +465,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
@@ -440,12 +485,14 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = Observations {
             immediate: Some(StubImmediate {
                 connected: true,
                 score: 0.95,
+                ack_rate: Some(0.9),
             }),
             intermediate: Some(StubIntermediate {
                 capacity: Some(1000),
@@ -468,6 +515,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_not_connected_and_intermediate();
@@ -487,6 +535,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_only_immediate();
@@ -506,12 +555,14 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = Observations {
             immediate: Some(StubImmediate {
                 connected: true,
                 score: 0.95,
+                ack_rate: Some(0.9),
             }),
             intermediate: Some(StubIntermediate {
                 capacity: None,
@@ -534,6 +585,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_empty();
@@ -555,6 +607,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
@@ -574,6 +627,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_capacity_only();
@@ -593,6 +647,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_not_connected_and_intermediate();
@@ -612,6 +667,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_only_immediate();
@@ -631,6 +687,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
@@ -650,6 +707,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = Observations {
@@ -675,6 +733,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_empty();
@@ -696,6 +755,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
@@ -715,6 +775,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
@@ -734,6 +795,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_only_immediate();
@@ -753,6 +815,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = Observations {
@@ -778,6 +841,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_capacity_only();
@@ -797,6 +861,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_empty();
@@ -816,6 +881,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
 
@@ -832,6 +898,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(1).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
@@ -851,6 +918,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(2).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
@@ -881,6 +949,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::forward(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_empty();
@@ -902,6 +971,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::returning(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         #[derive(serde::Serialize)]
         struct Invariants {
@@ -922,6 +992,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::returning(
             std::num::NonZeroUsize::new(2).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_not_connected_and_intermediate();
@@ -941,6 +1012,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::returning(
             std::num::NonZeroUsize::new(2).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
@@ -960,6 +1032,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::returning(
             std::num::NonZeroUsize::new(2).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_not_connected_and_intermediate();
@@ -979,6 +1052,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::returning(
             std::num::NonZeroUsize::new(2).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_not_connected_and_intermediate();
@@ -998,6 +1072,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::returning(
             std::num::NonZeroUsize::new(2).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_capacity_only();
@@ -1017,6 +1092,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::returning(
             std::num::NonZeroUsize::new(2).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_only_immediate();
@@ -1036,6 +1112,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::returning(
             std::num::NonZeroUsize::new(2).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_empty();
@@ -1055,7 +1132,7 @@ mod tests {
     #[test]
     fn return_last_edge_requires_connectivity() -> anyhow::Result<()> {
         let length = std::num::NonZeroUsize::new(2).context("should be non-zero")?;
-        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY);
+        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let ret_fn = ret.into_cost_fn();
 
         let obs_conn = with_connected_and_capacity();
@@ -1082,13 +1159,14 @@ mod tests {
     #[test]
     fn return_last_edge_positive_when_connected_with_empty_intermediate() -> anyhow::Result<()> {
         let length = std::num::NonZeroUsize::new(2).context("should be non-zero")?;
-        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY);
+        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let ret_fn = ret.into_cost_fn();
 
         let obs = Observations {
             immediate: Some(StubImmediate {
                 connected: true,
                 score: 0.95,
+                ack_rate: Some(0.9),
             }),
             intermediate: Some(StubIntermediate {
                 capacity: None,
@@ -1110,13 +1188,14 @@ mod tests {
     #[test]
     fn return_last_edge_penalized_when_connected_but_zero_score() -> anyhow::Result<()> {
         let length = std::num::NonZeroUsize::new(2).context("should be non-zero")?;
-        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY);
+        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let ret_fn = ret.into_cost_fn();
 
         let obs = Observations {
             immediate: Some(StubImmediate {
                 connected: true,
                 score: 0.0,
+                ack_rate: Some(0.9),
             }),
             intermediate: None,
         };
@@ -1136,8 +1215,8 @@ mod tests {
     fn forward_last_edge_differs_from_return_last_edge() -> anyhow::Result<()> {
         let length = std::num::NonZeroUsize::new(2).context("should be non-zero")?;
 
-        let fwd = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY);
-        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY);
+        let fwd = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
+        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let fwd_fn = fwd.into_cost_fn();
         let ret_fn = ret.into_cost_fn();
 
@@ -1168,6 +1247,7 @@ mod tests {
         let cost_fn = EdgeCostFn::<_, Observations>::returning(
             std::num::NonZeroUsize::new(3).context("should be non-zero")?,
             TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_capacity_only();
@@ -1186,8 +1266,8 @@ mod tests {
     fn return_intermediate_edge_same_as_forward() -> anyhow::Result<()> {
         let length = std::num::NonZeroUsize::new(3).context("should be non-zero")?;
 
-        let fwd = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY);
-        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY);
+        let fwd = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
+        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let fwd_fn = fwd.into_cost_fn();
         let ret_fn = ret.into_cost_fn();
 
@@ -1208,7 +1288,7 @@ mod tests {
     #[test]
     fn symmetrical_forward_without_self_loopback_works_with_forward_cost_fn() -> anyhow::Result<()> {
         let length = std::num::NonZeroUsize::new(2).context("should be non-zero")?;
-        let cost_fn = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY);
+        let cost_fn = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let f = cost_fn.into_cost_fn();
 
         let me_to_relay = with_connected_and_capacity();
@@ -1234,7 +1314,7 @@ mod tests {
     #[test]
     fn symmetrical_return_path_rejected_by_forward_cost_fn() -> anyhow::Result<()> {
         let length = std::num::NonZeroUsize::new(2).context("should be non-zero")?;
-        let cost_fn = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY);
+        let cost_fn = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let f = cost_fn.into_cost_fn();
 
         let dest_to_relay = with_not_connected_and_intermediate();
@@ -1260,7 +1340,7 @@ mod tests {
     #[test]
     fn symmetrical_return_path_works_with_return_cost_fn() -> anyhow::Result<()> {
         let length = std::num::NonZeroUsize::new(2).context("should be non-zero")?;
-        let cost_fn = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY);
+        let cost_fn = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let f = cost_fn.into_cost_fn();
 
         let dest_to_relay = with_not_connected_and_intermediate();
@@ -1287,7 +1367,7 @@ mod tests {
     fn symmetrical_bidirectional_both_paths_positive() -> anyhow::Result<()> {
         let length = std::num::NonZeroUsize::new(2).context("should be non-zero")?;
 
-        let fwd = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY);
+        let fwd = EdgeCostFn::<_, Observations>::forward(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let fwd_fn = fwd.into_cost_fn();
 
         let me_to_relay = with_connected_and_capacity();
@@ -1296,7 +1376,7 @@ mod tests {
         let fwd_cost = fwd_fn(1.0, &me_to_relay, 0);
         let fwd_cost = fwd_fn(fwd_cost, &relay_to_dest, 1);
 
-        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY);
+        let ret = EdgeCostFn::<_, Observations>::returning(length, TEST_PENALTY, TEST_MIN_ACK_RATE);
         let ret_fn = ret.into_cost_fn();
 
         let dest_to_relay = with_capacity_only();
@@ -1316,6 +1396,195 @@ mod tests {
             return_path_cost: ret_cost,
         });
 
+        Ok(())
+    }
+
+    // ── Ack rate cost function tests ─────────────────────────────────
+
+    #[test]
+    fn forward_first_edge_rejected_when_ack_rate_below_threshold() -> anyhow::Result<()> {
+        let cost_fn = EdgeCostFn::<_, Observations>::forward(
+            std::num::NonZeroUsize::new(3).context("should be non-zero")?,
+            TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
+        );
+        let f = cost_fn.into_cost_fn();
+        let obs = Observations {
+            immediate: Some(StubImmediate {
+                connected: true,
+                score: 0.95,
+                ack_rate: Some(0.05),
+            }),
+            intermediate: Some(StubIntermediate {
+                capacity: Some(1000),
+                score: 0.95,
+            }),
+        };
+
+        let cost = f(1.0, &obs, 0);
+        insta::assert_yaml_snapshot!(CostResult {
+            observations: obs,
+            initial_cost: 1.0,
+            path_index: 0,
+            result_cost: cost
+        });
+        Ok(())
+    }
+
+    #[test]
+    fn forward_first_edge_penalized_when_no_ack_data() -> anyhow::Result<()> {
+        let cost_fn = EdgeCostFn::<_, Observations>::forward(
+            std::num::NonZeroUsize::new(3).context("should be non-zero")?,
+            TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
+        );
+        let f = cost_fn.into_cost_fn();
+        let obs = Observations {
+            immediate: Some(StubImmediate {
+                connected: true,
+                score: 0.95,
+                ack_rate: None,
+            }),
+            intermediate: Some(StubIntermediate {
+                capacity: Some(1000),
+                score: 0.95,
+            }),
+        };
+
+        let cost = f(1.0, &obs, 0);
+        insta::assert_yaml_snapshot!(CostResult {
+            observations: obs,
+            initial_cost: 1.0,
+            path_index: 0,
+            result_cost: cost
+        });
+        Ok(())
+    }
+
+    #[test]
+    fn forward_first_edge_scales_by_ack_rate() -> anyhow::Result<()> {
+        let cost_fn = EdgeCostFn::<_, Observations>::forward(
+            std::num::NonZeroUsize::new(3).context("should be non-zero")?,
+            TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
+        );
+        let f = cost_fn.into_cost_fn();
+        let obs_high = Observations {
+            immediate: Some(StubImmediate {
+                connected: true,
+                score: 0.95,
+                ack_rate: Some(0.9),
+            }),
+            intermediate: Some(StubIntermediate {
+                capacity: Some(1000),
+                score: 0.95,
+            }),
+        };
+        let obs_low = Observations {
+            immediate: Some(StubImmediate {
+                connected: true,
+                score: 0.95,
+                ack_rate: Some(0.3),
+            }),
+            intermediate: Some(StubIntermediate {
+                capacity: Some(1000),
+                score: 0.95,
+            }),
+        };
+
+        let cost_high = f(1.0, &obs_high, 0);
+        let cost_low = f(1.0, &obs_low, 0);
+
+        assert!(
+            cost_high > cost_low,
+            "higher ack rate should produce higher cost: {cost_high} vs {cost_low}"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn return_last_edge_rejected_when_ack_rate_below_threshold() -> anyhow::Result<()> {
+        let cost_fn = EdgeCostFn::<_, Observations>::returning(
+            std::num::NonZeroUsize::new(2).context("should be non-zero")?,
+            TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
+        );
+        let f = cost_fn.into_cost_fn();
+        let obs = Observations {
+            immediate: Some(StubImmediate {
+                connected: true,
+                score: 0.95,
+                ack_rate: Some(0.05),
+            }),
+            intermediate: Some(StubIntermediate {
+                capacity: Some(1000),
+                score: 0.95,
+            }),
+        };
+
+        let cost = f(1.0, &obs, 1);
+        insta::assert_yaml_snapshot!(CostResult {
+            observations: obs,
+            initial_cost: 1.0,
+            path_index: 1,
+            result_cost: cost
+        });
+        Ok(())
+    }
+
+    #[test]
+    fn adversarial_peer_good_probes_but_zero_acks() -> anyhow::Result<()> {
+        let cost_fn = EdgeCostFn::<_, Observations>::forward(
+            std::num::NonZeroUsize::new(3).context("should be non-zero")?,
+            TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
+        );
+        let f = cost_fn.into_cost_fn();
+        let obs = Observations {
+            immediate: Some(StubImmediate {
+                connected: true,
+                score: 0.95,
+                ack_rate: Some(0.0),
+            }),
+            intermediate: Some(StubIntermediate {
+                capacity: Some(1000),
+                score: 0.95,
+            }),
+        };
+
+        let cost = f(1.0, &obs, 0);
+        insta::assert_yaml_snapshot!(CostResult {
+            observations: obs,
+            initial_cost: 1.0,
+            path_index: 0,
+            result_cost: cost
+        });
+        Ok(())
+    }
+
+    #[test]
+    fn forward_without_loopback_first_edge_rejected_when_ack_rate_below_threshold() -> anyhow::Result<()> {
+        let cost_fn = EdgeCostFn::<_, Observations>::forward_without_self_loopback(TEST_PENALTY, TEST_MIN_ACK_RATE);
+        let f = cost_fn.into_cost_fn();
+        let obs = Observations {
+            immediate: Some(StubImmediate {
+                connected: true,
+                score: 0.95,
+                ack_rate: Some(0.05),
+            }),
+            intermediate: Some(StubIntermediate {
+                capacity: Some(1000),
+                score: 0.95,
+            }),
+        };
+
+        let cost = f(1.0, &obs, 0);
+        insta::assert_yaml_snapshot!(CostResult {
+            observations: obs,
+            initial_cost: 1.0,
+            path_index: 0,
+            result_cost: cost
+        });
         Ok(())
     }
 }

--- a/api/src/graph/costs.rs
+++ b/api/src/graph/costs.rs
@@ -103,7 +103,8 @@ where
     /// - **First edge**: requires connectivity and intermediate capacity; scores by the better of
     ///   immediate/intermediate observations, then applies the ack rate modifier.
     /// - **Last edge**: accepts intermediate capacity or immediate connectivity; penalizes when neither is available
-    ///   (last hop is not monetized). Takes priority over first edge when `length == 1`.
+    ///   (last hop is not monetized). When `length == 1` the single edge is both first and last; the ack rate modifier
+    ///   is applied when immediate QoS data is available.
     /// - **Intermediate edges**: require capacity; penalize when unprobed.
     pub fn forward(length: std::num::NonZeroUsize, penalty: f64, min_ack_rate: f64) -> Self {
         let length = length.get();
@@ -118,14 +119,27 @@ where
                     if let Some(intermediate) = observation.intermediate_qos()
                         && intermediate.capacity().is_some()
                     {
-                        return score_or_penalize(cost, intermediate.score(), penalty);
+                        let base = score_or_penalize(cost, intermediate.score(), penalty);
+                        // For direct routes (length == 1) the single edge is also the immediate peer,
+                        // so apply ack rate when immediate data is available.
+                        if length == 1
+                            && let Some(immediate) = observation.immediate_qos()
+                        {
+                            return apply_ack_rate(immediate.ack_rate(), base, min_ack_rate, penalty);
+                        }
+                        return base;
                     }
 
                     // Fallback: use immediate connectivity score if available
                     if let Some(immediate) = observation.immediate_qos()
                         && immediate.is_connected()
                     {
-                        return score_or_penalize(cost, immediate.score(), penalty);
+                        let base = score_or_penalize(cost, immediate.score(), penalty);
+                        // Same as above: enforce ack rate for 1-hop routes
+                        if length == 1 {
+                            return apply_ack_rate(immediate.ack_rate(), base, min_ack_rate, penalty);
+                        }
+                        return base;
                     }
 
                     // Last hop is not monetized — penalize but do not reject
@@ -902,6 +916,36 @@ mod tests {
         );
         let f = cost_fn.into_cost_fn();
         let obs = with_connected_and_capacity();
+
+        let cost = f(1.0, &obs, 0);
+        insta::assert_yaml_snapshot!(CostResult {
+            observations: obs,
+            initial_cost: 1.0,
+            path_index: 0,
+            result_cost: cost
+        });
+        Ok(())
+    }
+
+    #[test]
+    fn forward_length_one_rejected_when_ack_rate_below_threshold() -> anyhow::Result<()> {
+        let cost_fn = EdgeCostFn::<_, Observations>::forward(
+            std::num::NonZeroUsize::new(1).context("should be non-zero")?,
+            TEST_PENALTY,
+            TEST_MIN_ACK_RATE,
+        );
+        let f = cost_fn.into_cost_fn();
+        let obs = Observations {
+            immediate: Some(StubImmediate {
+                connected: true,
+                score: 0.95,
+                ack_rate: Some(0.05),
+            }),
+            intermediate: Some(StubIntermediate {
+                capacity: Some(1000),
+                score: 0.95,
+            }),
+        };
 
         let cost = f(1.0, &obs, 0);
         insta::assert_yaml_snapshot!(CostResult {

--- a/api/src/graph/mod.rs
+++ b/api/src/graph/mod.rs
@@ -3,6 +3,7 @@ pub mod traits;
 pub mod types;
 
 pub use traits::{
-    CostFn, EdgeLinkObservable, NetworkGraphTraverse, NetworkGraphUpdate, NetworkGraphView, NetworkGraphWrite,
+    CostFn, EdgeImmediateProtocolObservable, EdgeLinkObservable, NetworkGraphTraverse, NetworkGraphUpdate,
+    NetworkGraphView, NetworkGraphWrite,
 };
 pub use types::*;

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__adversarial_peer_good_probes_but_zero_acks.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__adversarial_peer_good_probes_but_zero_acks.snap
@@ -6,8 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
-    ack_rate: 0.9
-  intermediate: ~
+    ack_rate: 0
+  intermediate:
+    capacity: 1000
+    score: 0.95
 initial_cost: 1
 path_index: 0
-result_cost: -1
+result_cost: -0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_negative_when_connected_intermediate_but_no_capacity.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_negative_when_connected_intermediate_but_no_capacity.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: ~
     score: 0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_penalized_when_no_ack_data.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_penalized_when_no_ack_data.snap
@@ -6,8 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
-    ack_rate: 0.9
-  intermediate: ~
+    ack_rate: ~
+  intermediate:
+    capacity: 1000
+    score: 0.95
 initial_cost: 1
 path_index: 0
-result_cost: -1
+result_cost: 0.475

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_positive_when_capacity_only_no_intermediate_probe.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_positive_when_capacity_only_no_intermediate_probe.snap
@@ -6,9 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0
 initial_cost: 1
 path_index: 0
-result_cost: 0.95
+result_cost: 0.855

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_positive_when_connected_with_capacity.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_positive_when_connected_with_capacity.snap
@@ -6,9 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0.95
 initial_cost: 1
 path_index: 0
-result_cost: 0.95
+result_cost: 0.855

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_rejected_when_ack_rate_below_threshold.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_rejected_when_ack_rate_below_threshold.snap
@@ -6,8 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
-    ack_rate: 0.9
-  intermediate: ~
+    ack_rate: 0.05
+  intermediate:
+    capacity: 1000
+    score: 0.95
 initial_cost: 1
 path_index: 0
-result_cost: -1
+result_cost: -0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_scales_by_immediate_score.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_first_edge_scales_by_immediate_score.snap
@@ -6,9 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0.95
 initial_cost: 2
 path_index: 0
-result_cost: 1.9
+result_cost: 1.71

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_intermediate_edge_negative_when_no_intermediate.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_intermediate_edge_negative_when_no_intermediate.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate: ~
 initial_cost: 1
 path_index: 1

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_intermediate_edge_scales_by_intermediate_score.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_intermediate_edge_scales_by_intermediate_score.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_last_edge_positive_when_capacity_and_score.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_last_edge_positive_when_capacity_and_score.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_last_edge_positive_with_connectivity_no_capacity.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_last_edge_positive_with_connectivity_no_capacity.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate: ~
 initial_cost: 1
 path_index: 2

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_last_edge_scales_by_intermediate_score.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_last_edge_scales_by_intermediate_score.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_length_one_has_only_first_and_last_edge.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_length_one_has_only_first_and_last_edge.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_length_one_rejected_when_ack_rate_below_threshold.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_length_one_rejected_when_ack_rate_below_threshold.snap
@@ -6,10 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
-    ack_rate: 0.9
+    ack_rate: 0.05
   intermediate:
     capacity: 1000
     score: 0.95
 initial_cost: 1
 path_index: 0
-result_cost: 0.855
+result_cost: -0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_length_two_intermediate_at_index_one.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_length_two_intermediate_at_index_one.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_without_loopback_first_edge_rejected_when_ack_rate_below_threshold.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__forward_without_loopback_first_edge_rejected_when_ack_rate_below_threshold.snap
@@ -6,8 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
-    ack_rate: 0.9
-  intermediate: ~
+    ack_rate: 0.05
+  intermediate:
+    capacity: 1000
+    score: 0.95
 initial_cost: 1
 path_index: 0
-result_cost: -1
+result_cost: -0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_first_edge_negative_when_no_capacity.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_first_edge_negative_when_no_capacity.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate: ~
 initial_cost: 1
 path_index: 0

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_first_edge_positive_with_full_data.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_first_edge_positive_with_full_data.snap
@@ -6,6 +6,7 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_last_edge_penalized_when_connected_but_zero_score.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_last_edge_penalized_when_connected_but_zero_score.snap
@@ -6,7 +6,8 @@ observations:
   immediate:
     connected: true
     score: 0
+    ack_rate: 0.9
   intermediate: ~
 initial_cost: 1
 path_index: 1
-result_cost: 0.5
+result_cost: 0.45

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_last_edge_positive_when_connected_with_empty_intermediate.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_last_edge_positive_when_connected_with_empty_intermediate.snap
@@ -6,9 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: ~
     score: 0
 initial_cost: 1
 path_index: 1
-result_cost: 0.95
+result_cost: 0.855

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_last_edge_rejected_when_ack_rate_below_threshold.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_last_edge_rejected_when_ack_rate_below_threshold.snap
@@ -6,10 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
-    ack_rate: 0.9
+    ack_rate: 0.05
   intermediate:
     capacity: 1000
     score: 0.95
 initial_cost: 1
 path_index: 1
-result_cost: 0.95
+result_cost: -0.95

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_last_edge_requires_connectivity.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__return_last_edge_requires_connectivity.snap
@@ -6,9 +6,10 @@ observations:
   immediate:
     connected: true
     score: 0.95
+    ack_rate: 0.9
   intermediate:
     capacity: 1000
     score: 0.95
 initial_cost: 1
 path_index: 1
-result_cost: 0.95
+result_cost: 0.855

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__symmetrical_bidirectional_both_paths_positive.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__symmetrical_bidirectional_both_paths_positive.snap
@@ -2,5 +2,5 @@
 source: api/src/graph/costs.rs
 expression: "BidirectionalCost\n{ forward_without_self_loopback_cost: fwd_cost, return_path_cost: ret_cost, }"
 ---
-forward_without_self_loopback_cost: 0.475
-return_path_cost: 0.475
+forward_without_self_loopback_cost: 0.4275
+return_path_cost: 0.4275

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__symmetrical_forward_without_self_loopback_works_with_forward_cost_fn.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__symmetrical_forward_without_self_loopback_works_with_forward_cost_fn.snap
@@ -2,5 +2,5 @@
 source: api/src/graph/costs.rs
 expression: "PathCost\n{ after_first_edge: cost_after_first, after_last_edge: cost_after_last, }"
 ---
-after_first_edge: 0.95
-after_last_edge: 0.475
+after_first_edge: 0.855
+after_last_edge: 0.4275

--- a/api/src/graph/snapshots/hopr_api__graph__costs__tests__symmetrical_return_path_works_with_return_cost_fn.snap
+++ b/api/src/graph/snapshots/hopr_api__graph__costs__tests__symmetrical_return_path_works_with_return_cost_fn.snap
@@ -3,4 +3,4 @@ source: api/src/graph/costs.rs
 expression: "PathCost\n{ after_first_edge: cost_after_first, after_last_edge: cost_after_last, }"
 ---
 after_first_edge: 0.95
-after_last_edge: 0.9025
+after_last_edge: 0.81225

--- a/api/src/graph/traits.rs
+++ b/api/src/graph/traits.rs
@@ -22,10 +22,8 @@ pub enum EdgeWeightType {
     Capacity(Option<Capacity>),
     /// An update to the physical connectivity status of this edge.
     Connected(bool),
-    /// A message was sent to the immediate peer on this edge.
-    MessageSent,
-    /// An acknowledgment was received from the immediate peer on this edge.
-    AckReceived,
+    /// An update to the immediate hop protocol conformance metrics (messages sent / acks received).
+    ImmediateProtocolConformance,
 }
 
 /// Trait for recording new observations onto a graph edge.

--- a/api/src/graph/traits.rs
+++ b/api/src/graph/traits.rs
@@ -23,7 +23,12 @@ pub enum EdgeWeightType {
     /// An update to the physical connectivity status of this edge.
     Connected(bool),
     /// An update to the immediate hop protocol conformance metrics (messages sent / acks received).
-    ImmediateProtocolConformance,
+    ImmediateProtocolConformance {
+        /// Total number of packets sent to the immediate peer.
+        num_packets: u64,
+        /// Total number of acknowledgments received from the immediate peer.
+        num_acks: u64,
+    },
 }
 
 /// Trait for recording new observations onto a graph edge.

--- a/api/src/graph/traits.rs
+++ b/api/src/graph/traits.rs
@@ -22,6 +22,10 @@ pub enum EdgeWeightType {
     Capacity(Option<Capacity>),
     /// An update to the physical connectivity status of this edge.
     Connected(bool),
+    /// A message was sent to the immediate peer on this edge.
+    MessageSent,
+    /// An acknowledgment was received from the immediate peer on this edge.
+    AckReceived,
 }
 
 /// Trait for recording new observations onto a graph edge.
@@ -45,10 +49,24 @@ pub trait EdgeProtocolObservable {
     fn capacity(&self) -> Option<u128>;
 }
 
+/// Trait for reading immediate hop protocol conformance metrics.
+///
+/// Tracks point-to-point message acknowledgment behavior between directly
+/// connected peers. The ack rate can be used by cost functions to detect
+/// adversarial nodes that drop or fail to acknowledge messages.
+pub trait EdgeImmediateProtocolObservable {
+    /// The ratio of acknowledged messages to sent messages for this immediate edge.
+    ///
+    /// Returns `None` when insufficient messages have been sent to compute
+    /// a meaningful ratio. Returns `Some(rate)` in the range \[0.0, 1.0\]
+    /// where 1.0 means all messages were acknowledged.
+    fn ack_rate(&self) -> Option<f64>;
+}
+
 /// Trait for reading aggregated quality-of-service observations from a graph edge.
 pub trait EdgeObservableRead {
-    /// Measurement type for direct (1-hop) probes, including network connectivity info.
-    type ImmediateMeasurement: EdgeLinkObservable + EdgeNetworkObservableRead + Send;
+    /// Measurement type for direct (1-hop) probes, including network connectivity and protocol conformance info.
+    type ImmediateMeasurement: EdgeLinkObservable + EdgeNetworkObservableRead + EdgeImmediateProtocolObservable + Send;
     /// Measurement type for relayed probes through an intermediate, including channel capacity.
     type IntermediateMeasurement: EdgeLinkObservable + EdgeProtocolObservable + Send;
 


### PR DESCRIPTION
## Summary

- Add `EdgeImmediateProtocolObservable` trait with `ack_rate()` for tracking point-to-point message acknowledgment behavior between directly connected peers
- Add `MessageSent` and `AckReceived` variants to `EdgeWeightType` for recording events
- Integrate ack rate into cost functions (`forward`, `returning`, `forward_without_self_loopback`) with configurable `min_ack_rate` threshold to detect and reject adversarial nodes

Closes #16

## Context

The hopr-api lacks interfaces for immediate hop message/ack tracking. Currently, the `ImmediateMeasurement` associated type only covers probe latency (`EdgeLinkObservable`) and connectivity (`EdgeNetworkObservableRead`). There is no trait surface for protocol conformance metrics — specifically the ratio of acknowledged messages to messages sent. Without this, cost functions cannot detect adversarial peers that claim connectivity but fail to acknowledge messages. This is a pre-requisite for [hoprnet/hoprnet#7654](https://github.com/hoprnet/hoprnet/issues/7654).

## Changes

### 1. New trait `EdgeImmediateProtocolObservable` — `api/src/graph/traits.rs`

Add a new trait next to `EdgeProtocolObservable` (its intermediate counterpart):

```rust
pub trait EdgeImmediateProtocolObservable {
    /// Ratio of acks received to messages sent for this immediate edge.
    /// Returns `None` when insufficient data exists for a meaningful ratio.
    fn ack_rate(&self) -> Option<f64>;
}
```

### 2. Update `ImmediateMeasurement` bound — `api/src/graph/traits.rs`

Add the new trait to the associated type bound on `EdgeObservableRead::ImmediateMeasurement`:

```rust
type ImmediateMeasurement: EdgeLinkObservable + EdgeNetworkObservableRead + EdgeImmediateProtocolObservable + Send;
```

### 3. New `EdgeWeightType` variants — `api/src/graph/traits.rs`

Add two unit variants for recording message/ack events:

```rust
/// A message was sent to the immediate peer on this edge.
MessageSent,
/// An acknowledgment was received from the immediate peer on this edge.
AckReceived,
```

### 4. New helper `apply_ack_rate` — `api/src/graph/costs.rs`

```rust
fn apply_ack_rate(ack_rate: Option<f64>, cost: f64, min_ack_rate: f64, penalty: f64) -> f64 {
    match ack_rate {
        Some(rate) if rate < min_ack_rate => -cost,
        Some(rate) => cost * rate,
        None => cost * penalty,
    }
}
```

### 5. Update cost function constructors — `api/src/graph/costs.rs`

Add `min_ack_rate: f64` parameter (clamped to `[0.0, 1.0]`) to:
- `forward(length, penalty, min_ack_rate)` — apply on **first edge** after connectivity+capacity check
- `returning(length, penalty, min_ack_rate)` — apply on **last edge** (relay -> me) after connectivity check
- `forward_without_self_loopback(penalty, min_ack_rate)` — apply on **first edge**

### 6. Export new trait — `api/src/graph/mod.rs`

### 7. Update tests — `api/src/graph/costs.rs`

- Add `ack_rate: Option<f64>` to `StubImmediate`, impl `EdgeImmediateProtocolObservable`
- Update all existing builders with sensible ack_rate values
- Add new test cases:
  - First edge rejected when ack_rate below threshold
  - First edge penalized when no ack data
  - First edge scales by ack_rate when above threshold
  - Return last edge rejected when ack_rate below threshold
  - Adversarial scenario: good probes but zero acks
  - Forward without loopback: first edge rejected when ack_rate below threshold

## Test plan

- [x] `cargo check -p hopr-api` — compiles
- [x] `cargo shear --fix` — no unused deps
- [x] `nix fmt` — formatted
- [x] `cargo clippy -p hopr-api --all-features` — no warnings
- [x] `cargo insta test -p hopr-api --features graph --accept` — all 49 tests pass, snapshots regenerated