### PR TITLE
feat: add deprecated `redeemed_value` to ChannelStats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2226,7 +2226,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 members = ["api"]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
 repository = "https://github.com/hoprnet/hopr-api"

--- a/api/src/tickets/mod.rs
+++ b/api/src/tickets/mod.rs
@@ -16,6 +16,9 @@ pub struct ChannelStats {
     pub unredeemed_value: HoprBalance,
     /// Total value of on-chain rejected tickets in this channel.
     pub rejected_value: HoprBalance,
+    /// Total value of on-chain redeemed tickets in this channel.
+    #[deprecated(since = "1.4.0", note = "read on-chain value instead once blokli#237 is merged")]
+    pub redeemed_value: HoprBalance,
     /// Total value of on-chain neglected tickets in this channel.
     pub neglected_value: HoprBalance,
 }


### PR DESCRIPTION
This is used in tests until https://github.com/hoprnet/blokli/pull/237 is merged,