### PR TITLE
fix: Remove pull_request_target for security reasons

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -5,7 +5,7 @@ name: Checks
 on:
   merge_group:
     types: [checks_requested]
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize

--- a/.github/workflows/open-pr.yaml
+++ b/.github/workflows/open-pr.yaml
@@ -3,7 +3,7 @@
 #################################################################################
 name: Open PR
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - reopened

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -7,7 +7,7 @@ env:
 on:
   merge_group:
     types: [checks_requested]
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - synchronize


### PR DESCRIPTION
Remove PR from forks for security reasons by changing the event from `pull_request_target` to `pull_request`