### PR TITLE
refactor(ci): use nix-action-v1 tag in workflows

### DIFF
--- a/.github/workflows/checks-audit.yaml
+++ b/.github/workflows/checks-audit.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: self-hosted-hoprnet-bigger
     steps:
       - name: Run Audit
-        uses: hoprnet/hopr-workflows/actions/nix-action@348f8878a2bc6e1f4f5be0e98ffc7b3f7a79cb67
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         with:
           source_branch: ${{ inputs.source_branch || github.ref }}
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/checks-cargo-deps.yaml
+++ b/.github/workflows/checks-cargo-deps.yaml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check cargo deps
-        uses: hoprnet/hopr-workflows/actions/nix-action@348f8878a2bc6e1f4f5be0e98ffc7b3f7a79cb67
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         with:
           source_branch: ${{ inputs.source_branch }}
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/checks-lint.yaml
+++ b/.github/workflows/checks-lint.yaml
@@ -24,7 +24,7 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Run linter
-        uses: hoprnet/hopr-workflows/actions/nix-action@348f8878a2bc6e1f4f5be0e98ffc7b3f7a79cb67
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         with:
           source_branch: ${{ inputs.source_branch || github.ref }}
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/checks-pre-commit.yaml
+++ b/.github/workflows/checks-pre-commit.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: self-hosted-hoprnet-small
     steps:
       - name: Run Pre-commit
-        uses: hoprnet/hopr-workflows/actions/nix-action@348f8878a2bc6e1f4f5be0e98ffc7b3f7a79cb67
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         with:
           source_branch: ${{ inputs.source_branch }}
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/checks-zizmor.yaml
+++ b/.github/workflows/checks-zizmor.yaml
@@ -25,7 +25,7 @@ jobs:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Run zizmor
-        uses: hoprnet/hopr-workflows/actions/nix-action@348f8878a2bc6e1f4f5be0e98ffc7b3f7a79cb67
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         with:
           source_branch: ${{ inputs.source_branch }}
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -25,7 +25,7 @@ jobs:
       CI: "true"
     steps:
       - name: Run unit tests
-        uses: hoprnet/hopr-workflows/actions/nix-action@348f8878a2bc6e1f4f5be0e98ffc7b3f7a79cb67
+        uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
         with:
           source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
           cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
 #     CI: "true"
 #   steps:
 #     - name: Run integration tests
-#       uses: hoprnet/hopr-workflows/actions/nix-action@9ffe6bb3713d11b1df070fb50546bb4321d8c693
+#       uses: hoprnet/hopr-workflows/actions/nix-action@c2aca7e56d25c4a786049ccf816c7f1af8721de8 # nix-action-v1
 #       with:
 #         repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
 #         ref: ${{ github.event.pull_request.head.ref || github.ref }}


### PR DESCRIPTION
## Summary
- Switch all nix-action references from commit hash to the stable `@nix-action-v1` tag (now that hopr-workflows PR is merged and tagged)

Follow-up to the previous PR #23 which was merged with hash references.

## Test plan
- [x] All CI checks pass with the tag reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)