### PR TITLE
fix(ci): bump publish-crates workflow to v3

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -127,7 +127,7 @@ jobs:
   publish-dry-run:
     name: Publish
     needs: [tests]
-    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@7a9f64fe68137982ff62973590c45beac5db184a # workflow-publish-crates-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@e4fadaa70234b9d734d5c51b6900602e55492ce2 # workflow-publish-crates-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -127,7 +127,7 @@ jobs:
   publish-dry-run:
     name: Publish
     needs: [tests]
-    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@acf901517a3207bb72874997ac060b38c32b21ba # workflow-publish-crates-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@7a9f64fe68137982ff62973590c45beac5db184a # workflow-publish-crates-v2
     permissions:
       contents: read
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
   publish:
     name: Publish
     needs: [build-library]
-    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@7a9f64fe68137982ff62973590c45beac5db184a # workflow-publish-crates-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@e4fadaa70234b9d734d5c51b6900602e55492ce2 # workflow-publish-crates-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -38,7 +38,7 @@ jobs:
   publish:
     name: Publish
     needs: [build-library]
-    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@acf901517a3207bb72874997ac060b38c32b21ba # workflow-publish-crates-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/publish-crates.yaml@7a9f64fe68137982ff62973590c45beac5db184a # workflow-publish-crates-v2
     permissions:
       contents: read
     with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.5.1"
+version = "1.5.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe07d79b33639dc62815fd60d9e2558846c91abd83a61306d0c533065d019db"
+checksum = "6084743d50e8aee75a629289f853c7cca1bd1db49e3942c292f11f7e6e7d9d0f"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,7 +67,7 @@ tracing = { version = "0.1.44", default-features = false, features = [
   "release_max_level_debug",
 ] }
 
-hopr-types = { version = "1.5.0", features = [
+hopr-types = { version = "1.5.1", features = [
   "crypto",
   "internal",
   "primitive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.5.1"
+version = "1.5.2"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"


### PR DESCRIPTION
## Summary

- Bump `publish-crates.yaml` workflow reference from `workflow-publish-crates-v1` to `workflow-publish-crates-v3`
- Patch bump hopr-api from 1.5.1 to 1.5.2
- Bump hopr-types dependency from 1.5.0 to 1.5.1