### PR TITLE
feat: add RedeemedStats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.5.3"
+version = "1.6.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.5.1"
+version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6084743d50e8aee75a629289f853c7cca1bd1db49e3942c292f11f7e6e7d9d0f"
+checksum = "3efb3f42c72ab2b00945ba3bd581131a2679fb3f3672940828730d402d8733a3"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.5.3"
+version = "1.6.0"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
@@ -67,7 +67,7 @@ tracing = { version = "0.1.44", default-features = false, features = [
   "release_max_level_debug",
 ] }
 
-hopr-types = { version = "1.5.1", features = [
+hopr-types = { version = "1.5.3", features = [
   "crypto",
   "internal",
   "primitive",

--- a/src/chain/accounts.rs
+++ b/src/chain/accounts.rs
@@ -62,7 +62,7 @@ pub trait ChainWriteAccountOperations {
         key: &OffchainKeypair,
     ) -> Result<BoxFuture<'life0, Result<ChainReceipt, Self::Error>>, AnnouncementError<Self::Error>>;
 
-    /// Withdraws native or token currency from the Safe or node account (depends on the used [`PayloadGenerator`]).
+    /// Withdraws native or token currency from the Safe or node account (depends on the used `PayloadGenerator`).
     async fn withdraw<C: Currency + Send>(
         &self,
         balance: Balance<C>,

--- a/src/chain/channels.rs
+++ b/src/chain/channels.rs
@@ -23,6 +23,7 @@ pub type DateTime = chrono::DateTime<chrono::Utc>;
 ///
 /// See [`ChainReadChannelOperations::stream_channels`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChannelSelector {
     /// Filter by source address.
     pub source: Option<Address>,

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -75,7 +75,7 @@ where
     type ChainError = E;
 }
 
-/// [`PathAddressResolver`] which uses the [HOPR chain API](self) to resolve addresses and channels.
+/// The `PathAddressResolver` which uses the [HOPR chain API](self) to resolve addresses and channels.
 ///
 /// This type implements a `From` trait for all types that implement both
 /// [`ChainKeyOperations`] and [`ChainReadChannelOperations`].

--- a/src/chain/safe.rs
+++ b/src/chain/safe.rs
@@ -8,6 +8,7 @@ use crate::chain::ChainReceipt;
 
 /// Information about a deployed Safe.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DeployedSafe {
     /// Safe address.
     pub address: Address,

--- a/src/chain/values.rs
+++ b/src/chain/values.rs
@@ -13,6 +13,7 @@ use hopr_types::{
 
 /// Contains domain separator information.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct DomainSeparators {
     /// HOPR Ledger smart contract domain separator.
     pub ledger: Hash,
@@ -24,6 +25,7 @@ pub struct DomainSeparators {
 
 /// Contains information about the HOPR on-chain network deployment.
 #[derive(Clone, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChainInfo {
     /// ID of the blockchain network (e.g.: `0x64` for Gnosis Chain)
     pub chain_id: u64,
@@ -31,6 +33,16 @@ pub struct ChainInfo {
     pub hopr_network_name: String,
     /// Addresses of the deployed HOPR smart contracts.
     pub contract_addresses: ContractAddresses,
+}
+
+/// Ticket redemption statistics for a Safe.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RedemptionStats {
+    /// Total number of tickets that have been redeemed.
+    pub redeemed_count: u64,
+    /// Total value of tickets that have been redeemed.
+    pub redeemed_value: HoprBalance,
 }
 
 /// Retrieves various on-chain information.
@@ -54,4 +66,6 @@ pub trait ChainValues {
     async fn channel_closure_notice_period(&self) -> Result<Duration, Self::Error>;
     /// Gets the information about the HOPR network on-chain deployment.
     async fn chain_info(&self) -> Result<ChainInfo, Self::Error>;
+    /// Gets the ticket redemption stats for the given safe address.
+    async fn redemption_stats<A: Into<Address>>(&self, safe_addr: A) -> Result<RedemptionStats, Self::Error>;
 }

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -1,7 +1,7 @@
 //! High-level HOPR node API trait definitions.
 //!
 //! This module defines the external API interface for interacting with a running HOPR node.
-//! The [`HoprNodeNetworkOperations`] and [`HoprNodeOperations`] traits provide the
+//! The `HoprNodeNetworkOperations` and `HoprNodeOperations` traits provide the
 //! operations available to external consumers, abstracting over implementation details.
 
 pub mod state;

--- a/src/tickets/mod.rs
+++ b/src/tickets/mod.rs
@@ -11,6 +11,10 @@ use crate::chain::{
 };
 
 /// Contains ticket statistics for an incoming channel.
+///
+/// The redeemed value should be retrieved directly from
+/// the chain instead (see [`ChainValues::redemption_stats`](crate::chain::ChainValues::redemption_stats) for more
+/// details).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ChannelStats {
@@ -20,9 +24,6 @@ pub struct ChannelStats {
     pub unredeemed_value: HoprBalance,
     /// Total value of on-chain rejected tickets in this channel.
     pub rejected_value: HoprBalance,
-    /// Total value of on-chain redeemed tickets in this channel.
-    #[deprecated(since = "1.4.0", note = "read on-chain value instead once blokli#237 is merged")]
-    pub redeemed_value: HoprBalance,
     /// Total value of on-chain neglected tickets in this channel.
     pub neglected_value: HoprBalance,
 }


### PR DESCRIPTION
Adds new chain API to query for ticket redemption stats in `ChainValues`.

Also adds proper serde derives as well.

Removes the deprecated `redeemed_value` field.