### PR TITLE
fix(nix): strip heavyweight test deps from pre-commit derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2234,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.5.3"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3efb3f42c72ab2b00945ba3bd581131a2679fb3f3672940828730d402d8733a3"
+checksum = "0d918bfe437f576b2395aa776e12bf678ba652fee5085a6ce77c8355f11fbbb0"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,7 +77,7 @@ tracing = { version = "0.1.44", default-features = false, features = [
   "release_max_level_debug",
 ] }
 
-hopr-types = { version = "1.5.3", features = [
+hopr-types = { version = "1.5.4", features = [
   "crypto",
   "internal",
   "primitive",

--- a/flake.nix
+++ b/flake.nix
@@ -96,8 +96,24 @@
             exec "${nightlyToolchain}/bin/rustfmt" "$@"
           '';
 
+          # pre-commit in nixpkgs bundles heavyweight test-only
+          # dependencies (dotnet-sdk, nodejs, go, coursier, …) into
+          # nativeBuildInputs via its preCheck string interpolation,
+          # even though doCheck is already false on Darwin.  Filter
+          # them out so `direnv allow` / `nix develop` doesn't have
+          # to build dotnet from source.
+          pre-commit-lightweight = pkgs.pre-commit.overridePythonAttrs {
+            nativeCheckInputs = [ ];
+            doCheck = false;
+            doInstallCheck = false;
+            dontUsePytestCheck = true;
+            preCheck = "";
+            postCheck = "";
+          };
+
           pre-commit-check = pre-commit.lib.${system}.run {
             src = ./.;
+            package = pre-commit-lightweight;
             hooks = {
               treefmt.enable = false;
               treefmt.package = config.treefmt.build.wrapper;
@@ -117,7 +133,6 @@
                 pass_filenames = false;
               };
             };
-            tools = pkgs;
           };
 
           devShell = nixLib.mkDevShell {


### PR DESCRIPTION
## Summary

- Override nixpkgs' `pre-commit` package to clear `nativeCheckInputs`, disable check/installCheck phases, and remove the `preCheck` dotnet reference that bakes `dotnet-sdk` into `nativeBuildInputs` via string interpolation even when `doCheck` is false on Darwin
- Remove unnecessary `tools = pkgs;` passed to `git-hooks.nix`

### Root cause

The `pre-commit` package in nixpkgs includes `dotnet-sdk`, `nodejs`, `go`, `coursier`, `cabal-install`, and `cargo` in its `nativeCheckInputs`. On Darwin `doCheck` is already `false`, but:

1. `doInstallCheck = true` causes the Python builder to include check inputs in `nativeBuildInputs`
2. The `preCheck` string contains `export DOTNET_ROOT="${dotnet-sdk}/share/dotnet"` — a Nix interpolation that creates a store path reference, making dotnet a build input even when the phase never runs

This forces a full dotnet SDK build from source on every `direnv allow` / `nix develop`, adding significant time to shell entry.

### Result

DevShell build plan: **10 derivations → 3 derivations** (no dotnet, no nodejs, no go, no coursier).