### PR TITLE
refactor(nix): remove dead code and slim down audit app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /target/
 **/*.rs.bk
 
+settings.local.json
+
 # Nix
 /result
 /result-*

--- a/flake.nix
+++ b/flake.nix
@@ -160,27 +160,9 @@
             ];
           };
 
-          run-check = flake-utils.lib.mkApp {
-            drv = pkgs.writeShellScriptBin "run-check" ''
-              set -e
-              check=$1
-              if [ -z "$check" ]; then
-                nix flake show --json 2>/dev/null | \
-                  jq -r '.checks."${system}" | to_entries | .[].key' | \
-                  xargs -I '{}' nix build ".#checks."${system}".{}"
-              else
-              	nix build ".#checks."${system}".$check"
-              fi
-            '';
-          };
-          run-audit = flake-utils.lib.mkApp {
-            drv = pkgs.writeShellApplication {
-              name = "audit";
-              runtimeInputs = [ pkgs-unstable.cargo-audit ];
-              text = ''
-                cargo-audit audit
-              '';
-            };
+          run-check = nixLib.mkCheckApp { inherit system; };
+          run-audit = nixLib.mkAuditApp {
+            rustToolchainFile = ./rust-toolchain.toml;
           };
         in
         {

--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,6 @@
       flake-utils,
       flake-parts,
       rust-overlay,
-      crane,
       nix-lib,
       pre-commit,
       ...
@@ -60,9 +59,6 @@
           ];
           pkgs = import nixpkgs { inherit localSystem overlays; };
           pkgs-unstable = import nixpkgs-unstable { inherit localSystem overlays; };
-
-          # Platform information
-          buildPlatform = pkgs.stdenv.buildPlatform;
 
           # Import nix-lib for shared Nix utilities
           nixLib = nix-lib.lib.${system};
@@ -180,12 +176,9 @@
           run-audit = flake-utils.lib.mkApp {
             drv = pkgs.writeShellApplication {
               name = "audit";
-              runtimeInputs = [
-                pkgs.cargo
-                pkgs-unstable.cargo-audit
-              ];
+              runtimeInputs = [ pkgs-unstable.cargo-audit ];
               text = ''
-                cargo audit
+                cargo-audit audit
               '';
             };
           };


### PR DESCRIPTION
## Summary

- Remove unused `buildPlatform` binding (dead code — nix-lib handles platform detection internally)
- Remove unused `crane` from outputs destructuring (accessed via nix-lib, not directly)
- Simplify `run-audit` app: invoke `cargo-audit audit` directly instead of `cargo audit`, dropping the full Rust toolchain (`pkgs.cargo`) from the app's runtime closure

### Audit app before/after

| | Before | After |
|---|---|---|
| `runtimeInputs` | `pkgs.cargo` + `pkgs-unstable.cargo-audit` | `pkgs-unstable.cargo-audit` |
| Direct inputs | cargo-audit + full Rust toolchain | cargo-audit only (4 inputs) |
| Invocation | `cargo audit` (subcommand) | `cargo-audit audit` (direct) |

### Investigated but not changed

- **`pkgs-unstable` import**: Still needed for `cargo-audit` 0.22.1 (stable 0.22.0 had build issues). The import is accessed lazily and only evaluates when the shells/app reference it.
- **nix-lib `corePackages`**: Includes `pkgs.cargo-audit` (0.22.0) which shadows the unstable version in the shell PATH. This is a nix-lib concern — the unstable version is available but second in PATH.
- **CI packages in devShell** (skopeo, dive, go-containerregistry): Bundled unconditionally by nix-lib's `mkDevShell`. Fixing requires an upstream nix-lib change.