### PR TITLE
feat(node): add ComponentStatus to graph accessor

### DIFF
--- a/src/node/accessors.rs
+++ b/src/node/accessors.rs
@@ -76,7 +76,7 @@ pub trait HasNetworkView {
 // HasGraphView
 // ---------------------------------------------------------------------------
 
-/// Provides read-only access to the network graph.
+/// Provides read-only access to the network graph and its health status.
 #[auto_impl::auto_impl(&, Arc)]
 pub trait HasGraphView {
     /// The concrete graph type, constrained to read-only operations.
@@ -87,6 +87,9 @@ pub trait HasGraphView {
 
     /// Returns a reference to the network graph.
     fn graph(&self) -> &Self::Graph;
+
+    /// Reports the current health of the graph component.
+    fn status(&self) -> ComponentStatus;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/node/mod.rs
+++ b/src/node/mod.rs
@@ -10,7 +10,7 @@
 //!
 //! - `HasChainApi` — chain interaction
 //! - `HasNetworkView` — network connectivity (read-only [`NetworkView`](crate::network::NetworkView))
-//! - `HasGraphView` — network graph (read-only)
+//! - `HasGraphView` — network graph (read-only) with component health status
 //! - `HasTransportApi` — transport operations (ping, observed multiaddresses)
 //! - `HasTicketManagement` — ticket processing
 //!


### PR DESCRIPTION
## Summary
- add status() -> ComponentStatus to HasGraphView for parity with other node accessors
- document that the graph accessor now exposes component health status
- update node module architecture docs to reflect graph status reporting
