### PR TITLE
feat(node): add ComponentStatusReporter trait and HoprState degradation variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1353,15 +1353,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "core2"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49ba7ef1ad6107f8824dbe97de947cbaac53c44e7f9756a1fba0d37c1eec505"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2887,12 +2878,21 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.3"
+version = "0.19.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b430e7953c29dd6a09afc29ff0bb69c6e306329ee6794700aee27b76a1aea8d"
+checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
 dependencies = [
- "core2",
+ "no_std_io2",
  "unsigned-varint",
+]
+
+[[package]]
+name = "no_std_io2"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2193,7 +2193,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.7.1"
+version = "1.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.7.1"
+version = "1.8.0"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"

--- a/src/node/accessors.rs
+++ b/src/node/accessors.rs
@@ -12,7 +12,10 @@ use std::time::Duration;
 use futures::Stream;
 use hopr_types::chain::chain_events::ChainEvent;
 
-use super::{ComponentStatus, EventWaitResult, NodeOnchainIdentity, TicketEvent, transport::TransportOperations};
+use super::{
+    ComponentStatus, ComponentStatusReporter, EventWaitResult, NodeOnchainIdentity, TicketEvent,
+    transport::TransportOperations,
+};
 use crate::{
     OffchainPublicKey,
     chain::HoprChainApi,
@@ -29,7 +32,7 @@ use crate::{
 #[auto_impl::auto_impl(&, Arc)]
 pub trait HasChainApi {
     /// The concrete chain API implementation.
-    type ChainApi: HoprChainApi + Clone + Send + Sync + 'static;
+    type ChainApi: HoprChainApi + ComponentStatusReporter + Clone + Send + Sync + 'static;
 
     /// Error type for node-level chain operations (distinct from on-chain errors).
     type ChainError: std::error::Error + Send + Sync + 'static;

--- a/src/node/state.rs
+++ b/src/node/state.rs
@@ -48,4 +48,12 @@ pub enum HoprState {
     /// Node has been shut down
     #[strum(to_string = "Node has been terminated")]
     Terminated = 10,
+
+    /// One or more components are degraded but the node is still operational
+    #[strum(to_string = "Node is running in degraded state")]
+    Degraded = 11,
+
+    /// One or more components are unavailable, node cannot function properly
+    #[strum(to_string = "Node has failed")]
+    Failed = 12,
 }

--- a/src/node/status.rs
+++ b/src/node/status.rs
@@ -1,7 +1,12 @@
+use std::borrow::Cow;
+
 /// Health status of an individual component within the HOPR node.
 ///
 /// Each component (chain, network, transport, tickets) reports its own status
 /// independently through its corresponding `Has*` accessor trait.
+///
+/// Detail messages use `Cow<'static, str>` so that components returning
+/// fixed diagnostic strings avoid heap allocation on every status query.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, strum::Display, strum::EnumIs)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ComponentStatus {
@@ -10,13 +15,13 @@ pub enum ComponentStatus {
     Ready,
     /// Component is starting up or waiting on a dependency.
     #[strum(to_string = "Initializing: {0}")]
-    Initializing(String),
+    Initializing(Cow<'static, str>),
     /// Component is running but in a degraded state.
     #[strum(to_string = "Degraded: {0}")]
-    Degraded(String),
+    Degraded(Cow<'static, str>),
     /// Component is not operational.
     #[strum(to_string = "Unavailable: {0}")]
-    Unavailable(String),
+    Unavailable(Cow<'static, str>),
 }
 
 /// Trait for components that can report their own health status.

--- a/src/node/status.rs
+++ b/src/node/status.rs
@@ -18,3 +18,15 @@ pub enum ComponentStatus {
     #[strum(to_string = "Unavailable: {0}")]
     Unavailable(String),
 }
+
+/// Trait for components that can report their own health status.
+///
+/// Implementors track their health internally and return the current
+/// [`ComponentStatus`] on demand. This enables the `Has*` accessor
+/// traits to delegate status queries directly to the underlying component
+/// rather than computing status from global node state.
+#[auto_impl::auto_impl(&, Arc)]
+pub trait ComponentStatusReporter {
+    /// Returns the current health status of this component.
+    fn component_status(&self) -> ComponentStatus;
+}


### PR DESCRIPTION
## Summary

- Add `ComponentStatusReporter` trait with `fn component_status(&self) -> ComponentStatus` so components can report their own health independently
- Add `ComponentStatusReporter` as a bound on `HasChainApi::ChainApi` so the chain accessor can delegate status to the underlying connector
- Extend `HoprState` with `Degraded` (= 11) and `Failed` (= 12) variants for deriving aggregate node health from component statuses

Dependency of hoprnet/hoprnet#8066 (component status reporting, fixes hoprnet/hoprnet#7722).