### PR TITLE
feat: select safe by deployer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2184,7 +2184,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.8.3"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.8.3"
+version = "1.9.0"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"

--- a/src/chain/safe.rs
+++ b/src/chain/safe.rs
@@ -12,32 +12,37 @@ use crate::chain::ChainReceipt;
 pub struct DeployedSafe {
     /// Safe address.
     pub address: Address,
-    /// Address of the Safe owner (typically the node chain key).
-    pub owner: Address,
+    /// Addresses of the Safe owners.
+    pub owners: Vec<Address>,
     /// Address of the Safe module.
     pub module: Address,
     /// Addresses of nodes that have been registered with this Safe.
     pub registered_nodes: Vec<Address>,
+    /// Address of the Safe deployer.
+    pub deployer: Address,
 }
 
 /// Selector for [deployed Safes](DeployedSafe).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum SafeSelector {
-    /// Selects Safes owned by the given address.
-    Owner(Address),
     /// Selects Safes with the given address.
     Address(Address),
+    /// Selects Safes deployed by the given address.
+    Deployer(Address),
     /// Selects Safes linked to the given node address
     NodeAddress(Address),
+    /// Selects Safes owned by the given address.
+    Owner(Address),
 }
 
 impl SafeSelector {
     /// Returns `true` if the given deployed Safe matches this selector.
     pub fn satisfies(&self, safe: &DeployedSafe) -> bool {
         match self {
-            SafeSelector::Owner(owner) => &safe.owner == owner,
             SafeSelector::Address(address) => &safe.address == address,
+            SafeSelector::Deployer(deployer) => &safe.deployer == deployer, 
             SafeSelector::NodeAddress(node_address) => safe.registered_nodes.contains(node_address),
+            SafeSelector::Owner(owner) => safe.owners.contains(owner),
         }
     }
 }


### PR DESCRIPTION
Allows to select safes using the SafeSelector by specifying one of the owner (that becomes a list, as there can be multiple owners, or by deployer. This lift the assumptions done until now that the owner is the deployer of the safe.