### PR TITLE
fix(ci): enforce nix fmt --ci via Format matrix entry

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -81,7 +81,7 @@ jobs:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@bbd22e57cf954c15f0a6051d59329857809141dd # workflow-tests-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       unit_tests: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,10 +72,9 @@ jobs:
           fi
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@18b6c2fec0b8f0240a83d2099cb40301c06585a0 # workflow-checks-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      format: true
       runner_small: depot-ubuntu-24.04
       runner_large: depot-ubuntu-24.04-4
     secrets:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,7 +72,7 @@ jobs:
           fi
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@2002c3d074e48378468372a6de710f88377c94e2 # workflow-checks-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@18b6c2fec0b8f0240a83d2099cb40301c06585a0 # workflow-checks-v2
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       format: true

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -84,9 +84,9 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      unit_tests: true
+      enable_unit_tests: true
       unit_test_command: "nix build -L .#unit-test"
-      runner: depot-ubuntu-24.04-4
+      runner_unit: depot-ubuntu-24.04-4
       test_timeout: 30
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,9 +72,10 @@ jobs:
           fi
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # workflow-checks-v1
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@2002c3d074e48378468372a6de710f88377c94e2 # workflow-checks-v1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      format: true
       runner_small: depot-ubuntu-24.04
       runner_large: depot-ubuntu-24.04-4
     secrets:


### PR DESCRIPTION
## Summary

- Adds \`format: true\` to the \`checks:\` CI job, enabling the new first-class \`Format\` matrix entry from [hopr-workflows#77](https://github.com/hoprnet/hopr-workflows/pull/77) (merged, tagged \`workflow-checks-v2\`)
- The \`Format\` job runs \`nix fmt -- --ci\` (treefmt: \`--no-cache --fail-on-change\`) as the first step so cheap formatting violations surface before heavier checks
- The repo is already clean (\`nix fmt -- --ci\` exits 0 on main) 

---
**Latest:** Bumped tests workflow to workflow-tests-v5 (69d61153fe24338ea983dd657496f0bc8b4cd819).