### PR TITLE
fix: use repo's devshell in the build-release workflow

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -22,7 +22,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # build-library-v2
     permissions:
       contents: read
     with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -105,7 +105,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: binary:aarch64-darwin
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # build-library-v2
     permissions:
       contents: read
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@64cb8ba34ff2e8caa43e366207d0cb1faa8d43d4 # build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # build-library-v2
     permissions:
       contents: read
     with:

--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,7 @@
             extraPackages = with pkgs; [
               pkgs-unstable.cargo-audit
               cargo-machete
+              cargo-release
               cargo-shear
               cargo-insta
             ];


### PR DESCRIPTION
Adds `cargo-release` to the devshell to avoid nested `nix` invocation in the `build-library` workflow.
Based on the changes in https://github.com/hoprnet/hopr-workflows/pull/78