### PR TITLE
feat(ci): add actionlint + pinact pre-commit hooks for workflow validation

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,3 @@
----
 self-hosted-runner:
   labels:
     - depot-ubuntu-24.04

--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+---
+self-hosted-runner:
+  labels:
+    - depot-ubuntu-24.04

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -22,7 +22,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -25,6 +25,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.base.ref }}
       version_type: pr

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -108,6 +108,7 @@ jobs:
     uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       version_type: commit

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       pull-requests: read
     steps:
-      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -105,7 +105,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: binary:aarch64-darwin
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6895dbbc515e39e0e283a68a80b8628ca6ead37a # build-library-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
     with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@6c5db2cd898f1f2c8fdae39498b6d7b3ee7d0258 # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@19d69bd81be66220932b18f1a7a655b422180b4e # build-library-v3
     permissions:
       contents: read
       id-token: write

--- a/flake.nix
+++ b/flake.nix
@@ -131,10 +131,7 @@
               renovate-config-validator = {
                 enable = true;
                 name = "Renovate config validator";
-                entry = "${pkgs.writeShellScript "validate-renovate" ''
-                  if [ -n "''${NIX_BUILD_TOP:-}" ]; then exit 0; fi
-                  ${pkgs.nodejs}/bin/npx --yes --package renovate -- renovate-config-validator "$@"
-                ''}";
+                entry = "${pkgs.renovate}/bin/renovate-config-validator";
                 files = "renovate\\.json$";
                 language = "system";
                 pass_filenames = true;
@@ -144,7 +141,15 @@
                 enable = true;
                 name = "pinact";
                 description = "Check GitHub Action refs are SHA-pinned and resolvable";
-                entry = "${pkgs.pinact}/bin/pinact run --check";
+                entry = "${pkgs.writeShellScript "pinact-check" ''
+                  token="''${GITHUB_TOKEN:-$(${pkgs.gh}/bin/gh auth token 2>/dev/null || true)}"
+                  if [ -z "$token" ]; then
+                    echo "pinact: skipping — no GITHUB_TOKEN and gh not authenticated" >&2
+                    exit 0
+                  fi
+                  export GITHUB_TOKEN="$token"
+                  exec ${pkgs.pinact}/bin/pinact run --check
+                ''}";
                 files = "^\\.github/workflows/.*\\.ya?ml$";
                 language = "system";
                 pass_filenames = false;

--- a/flake.nix
+++ b/flake.nix
@@ -179,6 +179,7 @@
             extraPackages = with pkgs; [
               pkgs-unstable.cargo-audit
               cargo-machete
+              cargo-release
               cargo-shear
               zizmor
             ];

--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,7 @@
             treefmtWrapper = config.treefmt.build.wrapper;
             treefmtPrograms = pkgs.lib.attrValues config.treefmt.build.programs;
             extraPackages = with pkgs; [
+              gh
               pkgs-unstable.cargo-audit
               cargo-machete
               cargo-release
@@ -165,8 +166,8 @@
               cargo-insta
             ];
             shellHook = ''
-              ${pre-commit-check.shellHook}
               export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+              ${pre-commit-check.shellHook}
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -145,7 +145,7 @@
                 name = "pinact";
                 description = "Check GitHub Action refs are SHA-pinned and resolvable";
                 entry = "${pkgs.pinact}/bin/pinact run --check";
-                files = "\\.ya?ml$";
+                files = "^\\.github/workflows/.*\\.ya?ml$";
                 language = "system";
                 pass_filenames = false;
               };
@@ -166,7 +166,7 @@
             ];
             shellHook = ''
               ${pre-commit-check.shellHook}
-              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
+              export GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -139,6 +139,16 @@
                 language = "system";
                 pass_filenames = true;
               };
+              actionlint.enable = true;
+              pinact = {
+                enable = true;
+                name = "pinact";
+                description = "Check GitHub Action refs are SHA-pinned and resolvable";
+                entry = "${pkgs.pinact}/bin/pinact run --check";
+                files = "\\.ya?ml$";
+                language = "system";
+                pass_filenames = false;
+              };
             };
           };
 
@@ -156,6 +166,7 @@
             ];
             shellHook = ''
               ${pre-commit-check.shellHook}
+              export GITHUB_TOKEN="$(gh auth token 2>/dev/null || true)"
             '';
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -166,7 +166,7 @@
             ];
             shellHook = ''
               ${pre-commit-check.shellHook}
-              export GITHUB_TOKEN="${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
+              export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
             '';
           };
 


### PR DESCRIPTION
Pins all remaining action refs to SHAs and adds actionlint + pinact pre-commit hooks via the flake. Note: depends on WIF migration PR merging first so pinact --check passes on hopr-workflows refs.