### PR TITLE
chore: bump released version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2263,7 +2263,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.12.1"
+version = "1.12.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2304,9 +2304,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "1.9.0"
+version = "1.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c80eeed436e90282f16d00dd1af6b73d72a58f66016c04a9fcc3de0328e063"
+checksum = "1d621ab243808540504b0a1e215743d45283e3133e7a4be44d2dd4cb31587a87"
 dependencies = [
  "aes",
  "anyhow",
@@ -2687,9 +2687,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.47.2"
+version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+checksum = "86f0f8fee8c926415c58d6ae43a08523a26faccb2323f5e6b644fe7dd4ef6b82"
 dependencies = [
  "console",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.12.1"
+version = "1.12.2"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
@@ -80,7 +80,7 @@ tracing = { version = "0.1.44", default-features = false, features = [
   "release_max_level_debug",
 ] }
 
-hopr-types = { version = "1.9.0", features = [
+hopr-types = { version = "1.9.1", features = [
   "crypto",
   "internal",
   "primitive",
@@ -89,7 +89,7 @@ hopr-types = { version = "1.9.0", features = [
 
 [dev-dependencies]
 anyhow = "1.0.102"
-insta = { version = "1.47.2", features = ["json", "yaml", "redactions"] }
+insta = { version = "1.48.0", features = ["json", "yaml", "redactions"] }
 mockall = "0.14.0"
 serde = { version = "1.0.228", features = ["derive"] }
 tokio = { version = "1.52.3", features = ["macros", "rt-multi-thread"] }


### PR DESCRIPTION
- Bump hopr-types from 1.9.0 to 1.9.1
- Bump insta from 1.47.2 to 1.48.0 (dev)
- Bump crate version to 1.12.2