### PR TITLE
fix(ci): migrate release build-library to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # build-library OIDC trusted publishing (hoprnet/hopr-workflows#84)
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

- Migrates the `release.yaml` build-library step from `build-library-v3` (`d0cffaf9`) to the OIDC trusted publishing version (`fa71078959cf9f`) — the same fix applied to `hopr-types` in hoprnet/hopr-types#78
- The `build-library-v3` workflow enforces `secrets.cargo_registry_token` when `version_type=release`, which we don't provide; the OIDC version authenticates to crates.io via `id-token` instead
- Without this fix, the next `Close release` run would fail with `secrets.cargo_registry_token is required when version_type='release'`