### PR TITLE
feat(ci): improve nix caching

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -22,7 +22,7 @@ jobs:
             runner: depot-ubuntu-24.04-arm-4
           - architecture: aarch64-darwin
             runner: depot-macos-15
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # build-library-v3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@3d291616a704bea189af1f16cefc25e26d2857c0 # build-library-v3.2.0
     permissions:
       contents: read
       id-token: write
@@ -30,6 +30,7 @@ jobs:
       source_branch: ${{ github.event.pull_request.base.ref }}
       version_type: pr
       architecture: ${{ matrix.architecture }}
+      build_command: "nix build -L .#lib-hopr-api-${{ matrix.architecture }}"
       timeout_minutes: 120
       package_name: hopr-api
       runner: ${{ matrix.runner }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -72,20 +72,22 @@ jobs:
           fi
   checks:
     name: Check
-    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@d0cffaf9e9209c8eca00e8c74e82ac3f5f3cf7bb # workflow-checks-v2
+    uses: hoprnet/hopr-workflows/.github/workflows/checks.yaml@3ee95c480962bb3c1fc0061887da9ba735f537c7 # workflow-checks-v2.1.1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
+      lint_command: "nix run -L .#check"
       runner_small: depot-ubuntu-24.04
       runner_large: depot-ubuntu-24.04-4
     secrets:
       cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
   tests:
     name: Test
-    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@69d61153fe24338ea983dd657496f0bc8b4cd819 # workflow-tests-v5
+    uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@3ee95c480962bb3c1fc0061887da9ba735f537c7 # workflow-tests-v6.1.1
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
-      enable_unit_tests: true
-      unit_test_command: "nix build -L .#unit-test"
+      enable_unit_tests: false
+      enable_unit_coverage: true
+      unit_coverage_command: "nix build -L .#coverage -o coverage.lcov"
       runner_unit: depot-ubuntu-24.04-4
       test_timeout: 30
     secrets:
@@ -105,7 +107,7 @@ jobs:
           - architecture: aarch64-darwin
             runner: depot-macos-15
             required_label: binary:aarch64-darwin
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@475421441ff5747c2233ebe58cdff355c8b40356 # build-library-v3.1.3
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@3d291616a704bea189af1f16cefc25e26d2857c0 # build-library-v3.2.0
     permissions:
       contents: read
       id-token: write
@@ -113,6 +115,7 @@ jobs:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       version_type: commit
       architecture: ${{ matrix.architecture }}
+      build_command: "nix build -L .#lib-hopr-api-${{ matrix.architecture }}"
       runner: ${{ matrix.runner }}
       timeout_minutes: 120
       package_name: hopr-api

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -83,6 +83,9 @@ jobs:
   tests:
     name: Test
     uses: hoprnet/hopr-workflows/.github/workflows/tests.yaml@3ee95c480962bb3c1fc0061887da9ba735f537c7 # workflow-tests-v6.1.1
+    permissions:
+      contents: read
+      id-token: write
     with:
       source_branch: ${{ github.event.pull_request.head.ref || github.ref }}
       enable_unit_tests: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   build-library:
     name: Build Library
-    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@fa71078959cf9f892185e8df16551720693a2cd1 # build-library OIDC trusted publishing (hoprnet/hopr-workflows#84)
+    uses: hoprnet/hopr-workflows/.github/workflows/build-library.yaml@3d291616a704bea189af1f16cefc25e26d2857c0 # build-library-v3.2.0
     permissions:
       contents: read
       id-token: write
@@ -26,6 +26,7 @@ jobs:
       source_branch: ${{ github.ref_name }}
       version_type: release
       architecture: x86_64-linux
+      build_command: "nix build -L .#lib-hopr-api-x86_64-linux"
       package_name: hopr-api
       runner: depot-ubuntu-24.04-4
     secrets:

--- a/flake.lock
+++ b/flake.lock
@@ -110,16 +110,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1774276825,
-        "narHash": "sha256-IV3mmWG5VvrP823sn5MBprMOe3ONKdMr9mc6LzFgGYM=",
+        "lastModified": 1785412696,
+        "narHash": "sha256-xXOyWF8zHVcgGzwdiWDuDX1ki24qbHqZjNLrQkk39yM=",
         "owner": "hoprnet",
         "repo": "nix-lib",
-        "rev": "42a9dba36c23f39301cc0d8b1c13be871e1964c6",
+        "rev": "e4d33e7c4ebc9ce3797a61b1e81fb06bab3dbac4",
         "type": "github"
       },
       "original": {
         "owner": "hoprnet",
-        "ref": "v1.1.0",
+        "ref": "v1.3.0",
         "repo": "nix-lib",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     crane.url = "github:ipetkov/crane/v0.23.4";
 
     # HOPR Nix Library (provides flake-utils and reusable build functions)
-    nix-lib.url = "github:hoprnet/nix-lib/v1.1.0";
+    nix-lib.url = "github:hoprnet/nix-lib/v1.3.0";
     pre-commit.url = "github:cachix/git-hooks.nix";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     flake-root.url = "github:srid/flake-root";
@@ -179,8 +179,20 @@
               cargo-insta
             ];
             shellHook = ''
+              # Runner-provided Nix binaries must not load libraries from this
+              # shell's newer glibc closure.
+              _hopr_ld_library_path="''${LD_LIBRARY_PATH-}"
+              unset LD_LIBRARY_PATH
+
               export GITHUB_TOKEN="''${GITHUB_TOKEN:-$(gh auth token 2>/dev/null || true)}"
               ${pre-commit-check.shellHook}
+
+              if [ -n "$_hopr_ld_library_path" ]; then
+                export LD_LIBRARY_PATH="$_hopr_ld_library_path"
+              else
+                unset LD_LIBRARY_PATH
+              fi
+              unset _hopr_ld_library_path
             '';
           };
 
@@ -253,7 +265,9 @@
             };
           };
 
-          checks = { inherit (hoprApiPackages) clippy; };
+          checks = {
+            inherit (hoprApiPackages) check clippy;
+          };
 
           apps = {
             check = run-check;

--- a/nix/packages/hopr-api.nix
+++ b/nix/packages/hopr-api.nix
@@ -38,33 +38,50 @@ let
       rev
       cargoToml
       ;
+    cargoExtraArgs = "--all-features";
   };
 
-  buildLib =
-    builder: args:
-    builder.callPackage nixLib.mkRustLibrary (
-      {
-        inherit
-          src
-          depsSrc
-          cargoToml
-          rev
-          ;
-      }
-      // args
-    );
+  buildLib = builder: args: builder.callPackage nixLib.mkRustLibrary (buildArgs // args);
+
+  clippyDerivation = buildLib builders.local { runClippy = true; };
+
+  # Reuse Clippy's dev-profile dependency artifacts for the standalone
+  # `cargo check` validation.
+  checkDerivation = clippyDerivation.overrideAttrs (_: {
+    pname = "hopr-api-check";
+    buildPhase = ''
+      runHook preBuild
+      cargo check --all-features
+      runHook postBuild
+    '';
+    installPhase = ''
+      mkdir -p "$out"
+    '';
+  });
 in
 {
 
-  clippy = buildLib builders.local { runClippy = true; };
+  check = checkDerivation;
+
+  clippy = clippyDerivation;
 
   unit-test = buildLib builders.local {
     src = testSrc;
     runTests = true;
-    cargoExtraArgs = "--all-features";
   };
 
-  docs = buildLib builders.localNightly { buildDocs = true; };
+  docs = builders.localNightly.callPackage nixLib.mkRustPackage (buildArgs // { buildDocs = true; });
+
+  coverage = builders.localCoverage.callPackage nixLib.mkRustPackage {
+    src = testSrc;
+    inherit
+      depsSrc
+      cargoToml
+      rev
+      ;
+    runCoverage = true;
+    cargoExtraArgs = "--all-features --lib";
+  };
 
   # Cross-compiled rlib packages
   # Artifacts are available at: ./result/lib/libhopr_api.rlib


### PR DESCRIPTION
- Upgrade `nix-lib` from `v1.1.0` to `v1.3.0`.
- Expose Cargo check and unit coverage as cacheable Nix derivations.
- Share dependency artifacts between Clippy and Cargo check.
- Run formatting, Clippy, and Cargo check through the existing cached `nix run -L .#check` entry point.
- Consolidate unit testing into the coverage derivation.
- Build libraries through architecture-specific `nix build` commands before Cargo package validation or publication.
- Enable Cachix reuse for library builds, linting, checks, coverage, and successful outputs.
- Prevent glibc conflicts when runner-provided Nix tools execute inside the development shell.