### PR TITLE
feat: add generic IncomingSession<S> beside HoprSessionServer

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+watch_file nix/*.nix
+watch_file rust-toolchain.toml
+use flake
+
+PATH_add .cargo/bin
+PATH_add target/debug/

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,6 @@ settings.local.json
 
 # direnv
 .direnv/
-.envrc
 
 # Python (if any tooling)
 __pycache__/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.18.2"
+version = "1.19.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2651,9 +2651,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4e0acce20fb83668e05ddfb277dca2b1b1408fd3df4e4859a8104c160afa050"
+version = "2.2.0"
+source = "git+https://github.com/hoprnet/hopr-types?branch=kauki%2Ffeat%2Ftypes%2Fnetwork-types-and-session-types#a8053a1e6234a022013f139b5d090738cc9a4416"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2652,7 +2652,8 @@ dependencies = [
 [[package]]
 name = "hopr-types"
 version = "2.2.0"
-source = "git+https://github.com/hoprnet/hopr-types?branch=kauki%2Ffeat%2Ftypes%2Fnetwork-types-and-session-types#a8053a1e6234a022013f139b5d090738cc9a4416"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1bff6165942aa235899cb5084a058db8a00b0885cfc41e8e0f5bf8b2cb007c6"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.18.2"
+version = "1.19.0"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
@@ -42,7 +42,7 @@ node = [
   "dep:auto_impl",
 ]
 node-session-client = ["node"]
-node-session-server = ["node"]
+node-session-server = ["node", "hopr-types/network"]
 serde = ["hopr-types/serde", "dep:serde"]
 tickets = ["chain", "dep:auto_impl"]
 types-random = ["hopr-types/random"]
@@ -80,7 +80,7 @@ tracing = { version = "0.1.44", default-features = false, features = [
   "release_max_level_debug",
 ] }
 
-hopr-types = { version = "2.1.1", features = [
+hopr-types = { version = "2.2.0", features = [
   "crypto",
   "internal",
   "primitive",
@@ -108,3 +108,8 @@ codegen-units = 1
 # make insta snapshots faster
 [profile.dev.package]
 insta.opt-level = 3
+
+# TEMPORARY (multi-repo chain bootstrap): hopr-types 2.2.0 is not yet on crates.io.
+# Remove once 2.2.0 is published.
+[patch.crates-io]
+hopr-types = { git = "https://github.com/hoprnet/hopr-types", branch = "kauki/feat/types/network-types-and-session-types" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,8 +108,3 @@ codegen-units = 1
 # make insta snapshots faster
 [profile.dev.package]
 insta.opt-level = 3
-
-# TEMPORARY (multi-repo chain bootstrap): hopr-types 2.2.0 is not yet on crates.io.
-# Remove once 2.2.0 is published.
-[patch.crates-io]
-hopr-types = { git = "https://github.com/hoprnet/hopr-types", branch = "kauki/feat/types/network-types-and-session-types" }

--- a/src/node/session/server.rs
+++ b/src/node/session/server.rs
@@ -2,6 +2,23 @@
 //!
 //! Gated behind the `node-session-server` feature.
 
+use hopr_types::network::{SessionId, SessionTarget};
+
+/// An incoming HOPR session to be processed by a [`HoprSessionServer`].
+///
+/// Generic over the concrete session byte-stream `S` (supplied by the implementor,
+/// typically hopr-lib), keeping transport-level types out of this crate. Only the
+/// plain [`SessionId`] and [`SessionTarget`] descriptors are named here.
+#[derive(Debug)]
+pub struct IncomingSession<S> {
+    /// Identifier of the incoming session.
+    pub id: SessionId,
+    /// The session byte-stream carrying the forwarded data.
+    pub session: S,
+    /// Describes where data received over the session should be forwarded.
+    pub target: SessionTarget,
+}
+
 /// Trait for processing incoming HOPR sessions on exit nodes.
 ///
 /// The concrete session type is defined by the implementor (typically hopr-lib),


### PR DESCRIPTION
## Summary

Step 3 of the multi-repo chain to make `hopr-session-server-forwarder` publishable.

Adds a generic **`IncomingSession<S> { id: SessionId, session: S, target: SessionTarget }`** next to `HoprSessionServer` (gated by `node-session-server`). Generic over the implementor's session byte-stream `S`, so — consistent with the trait's existing design note — **no transport-level concrete types enter this crate**; only the plain `SessionId`/`SessionTarget` descriptors (from `hopr_types::network`) are named.

Also:
- `node-session-server` now enables `hopr-types/network`; hopr-types bumped to 2.2.0 (published on crates.io).
- Adds a tracked repo **`.envrc`** (mirrors the sibling crates; `use flake`) and un-ignores it in `.gitignore`.

Version → 1.19.0. Validated: `cargo check/test --lib/clippy` green (59 tests), fmt clean.

Chain: hopr-types → hopr-utilities → **hopr-api** → hoprnet → hopr-impls.