### PR TITLE
feat: enhance `DepositPool` trait with keypair abstraction and add in-pool transfer methods

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -5,6 +5,7 @@ ignore = [
   "RUSTSEC-2026-0097", #  needs `alloy` to be updated
   "RUSTSEC-2026-0105", # 'core2' via 'multihash' [unmaintained], waiting on multiaddr update
   "RUSTSEC-2026-0173", # 'proc-macro-error2' via 'aquamarine' in 'hopr-types' [unmaintained], waiting on upstream update
+  "RUSTSEC-2026-0249", # `smartstring` unmaintained, requires `opentelemetry-prometheus-text-exporter` > 0.3.0
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.19.1"
+version = "1.20.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,9 +1126,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.91"
+version = "0.1.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae36dc4177970ef04fde5178d3e2429882def40e57a451f919c098f72baa6cec"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2651,9 +2651,9 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.2.0"
+version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1bff6165942aa235899cb5084a058db8a00b0885cfc41e8e0f5bf8b2cb007c6"
+checksum = "66c7725edf3080e937b9dcc66633003506c007da24706f6c3bcaf62443e2eb12"
 dependencies = [
  "aes",
  "anyhow",
@@ -4824,18 +4824,18 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ types-keypair = ["hopr-types/keypair"]
 types-with-bindings = ["types-chain", "hopr-types/use-bindings"]
 
 [dependencies]
-async-trait = "0.1.91"
+async-trait = "0.1.92"
 auto_impl = { version = "1.3.0", optional = true }
 atomic_enum = { version = "0.3.0", optional = true }
 chrono = { version = "0.4.45", default-features = false, features = [
@@ -74,13 +74,13 @@ libp2p-identity = { version = "0.2.14", features = [
 ] }
 serde = { version = "1.0.229", features = ["derive"], optional = true }
 strum = { version = "0.28.0", features = ["derive"] }
-thiserror = "2.0.19"
+thiserror = "2.0.20"
 tracing = { version = "0.1.44", default-features = false, features = [
   "std",
   "release_max_level_debug",
 ] }
 
-hopr-types = { version = "2.2.0", features = [
+hopr-types = { version = "2.2.1", features = [
   "crypto",
   "internal",
   "primitive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.19.1"
+version = "1.20.0"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"

--- a/src/chain/deposit_pool.rs
+++ b/src/chain/deposit_pool.rs
@@ -1,32 +1,44 @@
 use futures::future::{BoxFuture, join_all};
 pub use hopr_types::crypto::primitives::{PixDepositAddress, PixDepositSecret};
-use hopr_types::primitive::prelude::{Address, HoprBalance};
+use hopr_types::{
+    crypto::prelude::Keypair,
+    primitive::prelude::{Address, HoprBalance},
+};
+
+/// A future that resolves once `min_amount` has been deposited to the `dst` [`PixDepositAddress`]
+/// or an error occurs.
+pub type DepositNotification<'a, P, E> = BoxFuture<'a, Result<(P, HoprBalance), E>>;
 
 /// Contains abstraction over the deposit pool from PIX.
 ///
+/// The funds within this pool are represented by the given keypair `K`.
+///
+/// The secret and public key of the keypair should be convertible to [`PixDepositSecret`] and [`PixDepositAddress`], respectively
+/// The former is enforced by matching the [length of the keypair secret](Keypair::SecretLen) to the length of `PixDepositSecret`
+/// and the latter is enforced by the `Into<PixDepositAddress>` bound.
+///
 /// The implementations can be completely non-anonymous (e.g., plain Ethereum transactions from
-/// node's Safe to the [`PixDepositAddress`], if the `PixDepositAddress` and [`PixDepositSecret`] represent
-/// standard Ethereum keypair), or anonymous using a privacy pool in the background.
+/// node's Safe), or anonymous using a privacy pool in the background.
 ///
 /// In general, any anonymous privacy pool must be able to implement this trait
-/// to be used with PIX.
-///
-/// The operations MUST fail if used with `PixDepositAddress`/`PixDepositSecret` which are internally
-/// not compatible with the underlying pool's deposit address representation.
+/// to be used with PIX in production setup.
 ///
 /// The implementations should take care of all the retry/reliabililty of the operations, so the
 /// caller can assume that the operations will do best effort to succeed.
 #[async_trait::async_trait]
 #[auto_impl::auto_impl(&, Box, Arc)]
-pub trait DepositPool {
+pub trait DepositPool<K>
+where
+    K: Keypair<SecretLen = hopr_types::primitive::typenum::U32> + Send + Sync + 'static,
+    <K as Keypair>::Public: Into<PixDepositAddress> + Send + Sync + 'static,
+{
     /// Errors on failures.
     type Error: std::error::Error + Send + Sync + 'static;
     /// Some receipt returned on successful deposits and withdrawals.
     type Receipt: Send + Sync + 'static;
 
     /// Deposits `amount` of funds from node's Safe to the given `dst` deposit address.
-    async fn deposit_funds_to(&self, dst: PixDepositAddress, amount: HoprBalance)
-    -> Result<Self::Receipt, Self::Error>;
+    async fn deposit_funds_to(&self, dst: K::Public, amount: HoprBalance) -> Result<Self::Receipt, Self::Error>;
 
     /// Performs batch deposit of funds from node's Safe to multiple deposit addresses.
     ///
@@ -36,7 +48,7 @@ pub trait DepositPool {
     /// The method is allowed to return fewer receipts than deposits.
     async fn deposit_funds_to_multiple(
         &self,
-        deposits: Vec<(PixDepositAddress, HoprBalance)>,
+        deposits: Vec<(K::Public, HoprBalance)>,
     ) -> Result<Vec<Self::Receipt>, Self::Error> {
         let futures = deposits
             .into_iter()
@@ -49,9 +61,9 @@ pub trait DepositPool {
     /// The returned future is `'static` so it can be spawned independently of the borrow on `&self`.
     fn notify_deposit(
         &self,
-        dst: PixDepositAddress,
+        dst: K::Public,
         min_amount: HoprBalance,
-    ) -> Result<BoxFuture<'static, (PixDepositAddress, HoprBalance)>, Self::Error>;
+    ) -> Result<DepositNotification<'static, K::Public, Self::Error>, Self::Error>;
 
     /// Performs withdrawal of a previously made deposit using its [`PixDepositSecret`] to the
     /// `dst` Ethereum address.
@@ -60,7 +72,7 @@ pub trait DepositPool {
     /// otherwise withdraws the entire deposit.
     async fn withdraw_deposit(
         &self,
-        key: &PixDepositSecret,
+        key: &K,
         dst: Address,
         amount: Option<HoprBalance>,
     ) -> Result<Self::Receipt, Self::Error>;
@@ -71,16 +83,43 @@ pub trait DepositPool {
     /// Implementors may choose a more efficient pool-native batching.
     async fn withdraw_multiple_deposits(
         &self,
-        keys: &[PixDepositSecret],
+        keys: &[K],
         dst: Address,
-    ) -> Result<Vec<Result<(Address, Self::Receipt), Self::Error>>, Self::Error>
-    where
-        Self: Sync,
-    {
+    ) -> Result<Vec<Result<(Address, Self::Receipt), Self::Error>>, Self::Error> {
         let futures = keys.iter().map(|key| async move {
             self.withdraw_deposit(key, dst, None)
                 .await
                 .map(|receipt| (dst, receipt))
+        });
+        Ok(join_all(futures).await)
+    }
+
+    /// Transfers the funds from the deposit owned by `key` into another address within the pool.
+    ///
+    /// If `amount` is `None`, the entire deposit balance is transferred.
+    async fn pool_transfer(
+        &self,
+        key: &K,
+        dst: K::Public,
+        amount: Option<HoprBalance>,
+    ) -> Result<Self::Receipt, Self::Error>;
+
+    /// Performs batch [full transfer](Self::pool_transfer) of multiple deposits into a single deposit address.
+    ///
+    /// This default implementation simply concurrently calls [`self.pool_transfer`].
+    /// Implementors may choose a more efficient pool-native batching.
+    async fn pool_transfer_multiple(
+        &self,
+        keys: &[K],
+        dst: K::Public,
+    ) -> Result<Vec<Result<(K::Public, Self::Receipt), Self::Error>>, Self::Error> {
+        let futures = keys.iter().map(|key| {
+            let dst = dst.clone();
+            async move {
+                self.pool_transfer(key, dst.clone(), None)
+                    .await
+                    .map(|receipt| (dst, receipt))
+            }
         });
         Ok(join_all(futures).await)
     }

--- a/src/chain/deposit_pool.rs
+++ b/src/chain/deposit_pool.rs
@@ -13,9 +13,9 @@ pub type DepositNotification<'a, P, E> = BoxFuture<'a, Result<(P, HoprBalance), 
 ///
 /// The funds within this pool are represented by the given keypair `K`.
 ///
-/// The secret and public key of the keypair should be convertible to [`PixDepositSecret`] and [`PixDepositAddress`], respectively
-/// The former is enforced by matching the [length of the keypair secret](Keypair::SecretLen) to the length of `PixDepositSecret`
-/// and the latter is enforced by the `Into<PixDepositAddress>` bound.
+/// The secret and public key of the keypair should be convertible to [`PixDepositSecret`] and [`PixDepositAddress`],
+/// respectively The former is enforced by matching the [length of the keypair secret](Keypair::SecretLen) to the length
+/// of `PixDepositSecret` and the latter is enforced by the `Into<PixDepositAddress>` bound.
 ///
 /// The implementations can be completely non-anonymous (e.g., plain Ethereum transactions from
 /// node's Safe), or anonymous using a privacy pool in the background.


### PR DESCRIPTION
The `DepositPool` is now strictly tied to a certain keypair, which prevents using incompatible pools with each other.