### PR TITLE
feat: add ChainReadServiceOperations to the chain API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -774,9 +774,20 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69eab57e8d2663efa5c63135b2af4f396d66424f88954c21104125ab6b3e6bc"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
+]
+
+[[package]]
+name = "ark-bn254"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bc66f96ebe2a17a499475b4f94791d379817592ef494171586967ffdc6f95db"
+dependencies = [
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-std 0.6.0",
 ]
 
 [[package]]
@@ -787,13 +798,34 @@ checksum = "43d68f2d516162846c1238e755a7c4d131b892b70cc70c471a8e3ca3ed818fce"
 dependencies = [
  "ahash",
  "ark-ff 0.5.0",
- "ark-poly",
+ "ark-poly 0.5.0",
  "ark-serialize 0.5.0",
  "ark-std 0.5.0",
  "educe",
  "fnv",
  "hashbrown 0.15.5",
  "itertools 0.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "zeroize",
+]
+
+[[package]]
+name = "ark-ec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8352a2b2aedf6ba2cc38f7520fc51191d518dde96175c729af19f2d059f191c4"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-poly 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
+ "itertools 0.14.0",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -979,6 +1011,21 @@ dependencies = [
  "educe",
  "fnv",
  "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "ark-poly"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75f55af10b672002b8d953e230282c51206842e20e5791a94432219b4201de5c"
+dependencies = [
+ "ahash",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
+ "ark-std 0.6.0",
+ "educe",
+ "fnv",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1175,7 +1222,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e657c11493f07dd18f0c6055b58e77ca71e30ed34f2804468b22f89e36dc0a"
 dependencies = [
- "ark-ec",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "elliptic-curve 0.14.1",
@@ -2526,6 +2573,7 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
  "foldhash",
  "serde",
  "serde_core",
@@ -2633,8 +2681,8 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.2"
-source = "git+https://github.com/hoprnet/contracts?rev=6ce45eb5e7d433545d82ea32e27562eb0fc329c3#6ce45eb5e7d433545d82ea32e27562eb0fc329c3"
+version = "4.14.0"
+source = "git+https://github.com/hoprnet/contracts?rev=0eea1981c67343e65ff4e5ecb0b81b9ddc201b14#0eea1981c67343e65ff4e5ecb0b81b9ddc201b14"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2651,11 +2699,15 @@ dependencies = [
 [[package]]
 name = "hopr-types"
 version = "2.3.0"
-source = "git+https://github.com/hoprnet/hopr-types?rev=2a3bb391f1f98475d033b105c69090d050aaff0c#2a3bb391f1f98475d033b105c69090d050aaff0c"
+source = "git+https://github.com/hoprnet/hopr-types?rev=68d626ba041da06fde90c9c3c51a4d53c5ab0c4c#68d626ba041da06fde90c9c3c51a4d53c5ab0c4c"
 dependencies = [
  "aes",
  "anyhow",
  "aquamarine",
+ "ark-bn254 0.6.0",
+ "ark-ec 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "arrayvec",
  "async-trait",
  "babyjubjub-ec",
@@ -4789,8 +4841,8 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b5a2cc31c90e79778c4f6375e5d9828171d320db3f8c911a8ad47af4a70069"
 dependencies = [
- "ark-bn254",
- "ark-ec",
+ "ark-bn254 0.5.0",
+ "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-std 0.5.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2634,6 +2634,7 @@ dependencies = [
 [[package]]
 name = "hopr-bindings"
 version = "4.12.2"
+source = "git+https://github.com/hoprnet/contracts?rev=6ce45eb5e7d433545d82ea32e27562eb0fc329c3#6ce45eb5e7d433545d82ea32e27562eb0fc329c3"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2650,6 +2651,7 @@ dependencies = [
 [[package]]
 name = "hopr-types"
 version = "2.3.0"
+source = "git+https://github.com/hoprnet/hopr-types?rev=2a3bb391f1f98475d033b105c69090d050aaff0c#2a3bb391f1f98475d033b105c69090d050aaff0c"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.20.1"
+version = "1.21.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2633,9 +2633,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-bindings"
-version = "4.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9002389b5e9013a604cb654dc89152bd4c32ea64031f7f4837a8631c27ca2c51"
+version = "4.12.2"
 dependencies = [
  "alloy",
  "anyhow",
@@ -2651,9 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-types"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66c7725edf3080e937b9dcc66633003506c007da24706f6c3bcaf62443e2eb12"
+version = "2.3.0"
 dependencies = [
  "aes",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
+checksum = "9867f85f660948ddbef071ae484027654c04b62c7decd5b61464a7ed1f8931a0"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -79,9 +79,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
+checksum = "12a542fe1e6a48cfd010a9e8eba1235436de58ee0f1415e588c27d5d556e98df"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -106,9 +106,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
+checksum = "05ac1559726a5e71d6dbab59cbd8ad0988c762105d2ae41ae4f3241a3166262d"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -120,9 +120,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee5c8b5baa015ef1d07a33983794e1539cce36954846a9bc6e1050d8a1ebf9b7"
+checksum = "b86722084d6d07822a6c67e39ae794d437fb9de12fa4127d4f9fd93f89651121"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -138,7 +138,9 @@ dependencies = [
  "futures-util",
  "serde_json",
  "thiserror",
+ "tokio",
  "tracing",
+ "wasmtimer",
 ]
 
 [[package]]
@@ -225,9 +227,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
+checksum = "d40246adf7468b430fce87945ece8a54ef27fa760dd9f670f5162a412007bdb2"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -248,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-ens"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "709ddd5c63a05ac3274143ed0589e129119206f65cf094d2e727499da23efae8"
+checksum = "be9aa797694e7c55b007aa8f172daef76a83272cbedb8800bdc7038eed3bdb1a"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -262,9 +264,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027ba57264c5d05e4ff52e6090b3592e7526f5d5f5a844add6bbdd17c071c911"
+checksum = "4951473e6ff25cdf82eb87b6a1a5fbb4af9c97528398a4a62fbf516198ec5028"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -302,9 +304,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4691c60de5d628533752cd07e102d17c47874c06c04c91af33960fd94c484f4"
+checksum = "7e5722ea29a9a85ecdba2516c58f50d71e77cd25f8ce7e9f4ee8570ddeee6df1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -317,9 +319,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d912bb639bf4ac31e83095afe9e907c8b9774ce0c405966228368309fcfc45f"
+checksum = "e2e4d278913f00ab611f5367448a3a800fed173ab791c3cc67b7a1b0d7afd305"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -343,9 +345,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
+checksum = "e4e52ae56d1acaa6b46e9d7015b8ae6c10f3d1c213a32ae70b17426a03ae6729"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -356,9 +358,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-node-bindings"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab58d45ceaabba867fc05f018f58e4640df2e6424b4c759d45f66cf075ad8fe"
+checksum = "cdbb4a1bc03b411a3880d410ccc48d866b72d753ab1080605631890955b9caa2"
 dependencies = [
  "alloy-genesis",
  "alloy-hardforks",
@@ -407,9 +409,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7d526d184d392a8fbcf4293e457789b307bb70646e4f8b902989a246529450"
+checksum = "386124639a5c386329b9f2ef2b42969badbf7bba40422b513e3e5739c516dc34"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -470,9 +472,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
+checksum = "3dfd3ebc1756426a6a9e17979d4467632aff01f359136c50e5320ac6e32d6b8d"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -493,9 +495,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96deb317fe224e98a8ae17a7ed7ea63478867385bf50b7abd53642b24cfd811a"
+checksum = "417dc664965e36fc43a4f9c8eb8b2d14067a29c430e23470d2c923c1c977bac7"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -505,9 +507,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f89d27756bf3effdac25d07692724e840ce90ca1ff956a6b47dd2ae1612f597"
+checksum = "5a07bb602ee07767e393b5862f719a1d061deca15e617fbb1f7af49cd49576e4"
 dependencies = [
  "alloy-primitives",
  "alloy-rpc-types-eth",
@@ -517,9 +519,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a513723ef0b90c3b072f65eebf54d6ebc8b651d06734e252d024bd89b88ac"
+checksum = "cd0a6cce3f97e5d9c0048081b5d173e0e406c2056c52c012e578a1d451ff0cdc"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -532,9 +534,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
+checksum = "1eb4c87dfdde83cd97e03a8c0c5e986b52e14075e02266e322ac6c7eb02e7399"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -553,9 +555,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
+checksum = "2ff89f75b8a9d00f659750e9220c31b42d67c69ffc43b2ac8911dfd0506eb4a6"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -564,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
+checksum = "69e1f6fae3ade809daa4c32bee35a30a439bb307209d7b42f3995988b5cc74b8"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -579,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c880813cd26bd1ddf8c2236e31295896efd1fcc5cc761d8894ae894503aeea53"
+checksum = "621cc39c34b85875858ef149598f3d5f9797dff9a3247f3606fcc06f9b20acc8"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -668,9 +670,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
+checksum = "06f4ca8484d6295d5165f67de8fdb00ae630ba585efb606f003171286b56441c"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
@@ -691,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
+checksum = "8342aa5a7f8dee6d606307eebbc847d9799a823c7e4f37b9c1e32b08715f73c8"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -723,9 +725,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.1.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
+checksum = "1d0626c4f3b2028f7e8db32f53c22d9ecd5939f772317b7c4b6fe5219cb0589a"
 dependencies = [
  "darling",
  "proc-macro2",
@@ -2558,22 +2560,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
+ "equivalent",
  "foldhash",
  "serde",
  "serde_core",
@@ -3272,11 +3264,11 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
-version = "0.16.4"
+version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
+checksum = "5d2f2f9b4ba7e6b24d95e7e899329d35be83bcded72c8540cdd5368932d1d90a"
 dependencies = [
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ tracing = { version = "0.1.44", default-features = false, features = [
   "release_max_level_debug",
 ] }
 
-hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "2a3bb391f1f98475d033b105c69090d050aaff0c", features = [
+hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "68d626ba041da06fde90c9c3c51a4d53c5ab0c4c", features = [
   "crypto",
   "internal",
   "primitive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.20.1"
+version = "1.21.0"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"
@@ -80,7 +80,7 @@ tracing = { version = "0.1.44", default-features = false, features = [
   "release_max_level_debug",
 ] }
 
-hopr-types = { version = "2.2.1", features = [
+hopr-types = { version = "2.3.0", features = [
   "crypto",
   "internal",
   "primitive",
@@ -108,3 +108,14 @@ codegen-units = 1
 # make insta snapshots faster
 [profile.dev.package]
 insta.opt-level = 3
+
+# TODO: revert to crates.io versions once contracts publishes hopr-bindings 4.12.2 and
+# hopr-types publishes 2.3.0. Mirrors the TODO in hopr-types/Cargo.toml.
+[patch.crates-io]
+hopr-bindings = { path = "../contracts/ethereum/bindings" }
+hopr-types = { path = "../hopr-types" }
+
+# hopr-types pins hopr-bindings to a contracts git rev, so patching crates.io alone leaves two
+# copies of the crate in the graph and their alloy types stop unifying.
+[patch."https://github.com/hoprnet/contracts"]
+hopr-bindings = { path = "../contracts/ethereum/bindings" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ tracing = { version = "0.1.44", default-features = false, features = [
   "release_max_level_debug",
 ] }
 
-hopr-types = { version = "2.3.0", features = [
+hopr-types = { git = "https://github.com/hoprnet/hopr-types", rev = "2a3bb391f1f98475d033b105c69090d050aaff0c", features = [
   "crypto",
   "internal",
   "primitive",
@@ -108,14 +108,3 @@ codegen-units = 1
 # make insta snapshots faster
 [profile.dev.package]
 insta.opt-level = 3
-
-# TODO: revert to crates.io versions once contracts publishes hopr-bindings 4.12.2 and
-# hopr-types publishes 2.3.0. Mirrors the TODO in hopr-types/Cargo.toml.
-[patch.crates-io]
-hopr-bindings = { path = "../contracts/ethereum/bindings" }
-hopr-types = { path = "../hopr-types" }
-
-# hopr-types pins hopr-bindings to a contracts git rev, so patching crates.io alone leaves two
-# copies of the crate in the graph and their alloy types stop unifying.
-[patch."https://github.com/hoprnet/contracts"]
-hopr-bindings = { path = "../contracts/ethereum/bindings" }

--- a/src/chain/events.rs
+++ b/src/chain/events.rs
@@ -13,6 +13,9 @@ pub enum StateSyncOptions {
     /// The current state of all accounts (also private ones) is emitted as [`ChainEvent::Announcement`] events
     /// in the stream, preceding all the future events of that kind.
     AllAccounts,
+    /// The current registry-wide type registration fee and node-safe registry pointer are emitted
+    /// before future changes to either value.
+    ServiceRegistryConfig,
 }
 
 /// Allows subscribing to on-chain events.

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -4,7 +4,7 @@
 //! - Account operations (read/write)
 //! - Channel operations (read/write)
 //! - Safe operations (read/write)
-//! - Service registry operations (read)
+//! - Service registry operations (read/write)
 //! - Key operations (packet↔chain key mapping)
 //! - Chain events (subscription)
 //! - Chain values (configuration queries)
@@ -44,6 +44,7 @@ pub trait HoprChainApi:
     + ChainReadSafeOperations<Error = Self::ChainError>
     + ChainWriteSafeOperations<Error = Self::ChainError>
     + ChainReadServiceOperations<Error = Self::ChainError>
+    + ChainWriteServiceOperations<Error = Self::ChainError>
     + ChainEvents<Error = Self::ChainError>
     + ChainKeyOperations<Error = Self::ChainError>
     + ChainValues<Error = Self::ChainError>
@@ -62,6 +63,7 @@ where
         + ChainReadSafeOperations<Error = E>
         + ChainWriteSafeOperations<Error = E>
         + ChainReadServiceOperations<Error = E>
+        + ChainWriteServiceOperations<Error = E>
         + ChainEvents<Error = E>
         + ChainKeyOperations<Error = E>
         + ChainValues<Error = E>

--- a/src/chain/mod.rs
+++ b/src/chain/mod.rs
@@ -4,6 +4,7 @@
 //! - Account operations (read/write)
 //! - Channel operations (read/write)
 //! - Safe operations (read/write)
+//! - Service registry operations (read)
 //! - Key operations (packet↔chain key mapping)
 //! - Chain events (subscription)
 //! - Chain values (configuration queries)
@@ -14,6 +15,7 @@ mod deposit_pool;
 mod events;
 mod keys;
 mod safe;
+mod services;
 mod tickets;
 mod values;
 
@@ -23,6 +25,7 @@ pub use deposit_pool::*;
 pub use events::*;
 pub use keys::*;
 pub use safe::*;
+pub use services::*;
 pub use tickets::*;
 pub use values::*;
 
@@ -40,6 +43,7 @@ pub trait HoprChainApi:
     + ChainWriteChannelOperations<Error = Self::ChainError>
     + ChainReadSafeOperations<Error = Self::ChainError>
     + ChainWriteSafeOperations<Error = Self::ChainError>
+    + ChainReadServiceOperations<Error = Self::ChainError>
     + ChainEvents<Error = Self::ChainError>
     + ChainKeyOperations<Error = Self::ChainError>
     + ChainValues<Error = Self::ChainError>
@@ -57,6 +61,7 @@ where
         + ChainWriteChannelOperations<Error = E>
         + ChainReadSafeOperations<Error = E>
         + ChainWriteSafeOperations<Error = E>
+        + ChainReadServiceOperations<Error = E>
         + ChainEvents<Error = E>
         + ChainKeyOperations<Error = E>
         + ChainValues<Error = E>

--- a/src/chain/services.rs
+++ b/src/chain/services.rs
@@ -1,0 +1,222 @@
+use futures::stream::BoxStream;
+pub use hopr_types::internal::prelude::{ServiceEntry, ServiceMetadata, ServiceType};
+use hopr_types::primitive::prelude::{Address, HoprBalance};
+
+/// Registry configuration of a single service type.
+///
+/// Mirrors the per-type record of `HoprServiceRegistry`, whose changes are reported by the
+/// `ChainEvent::ServiceType*` variants.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ServiceTypeConfig {
+    /// Owner of the service type, or `None` if the type was abandoned.
+    ///
+    /// Abandoning is one-way: an abandoned type keeps this configuration forever.
+    pub owner: Option<Address>,
+    /// Requirement contract gating registrations under the type, or `None` if the type is open.
+    ///
+    /// An open type applies no policy beyond the Safe binding and the burn.
+    pub requirement: Option<Address>,
+    /// Amount burned when registering an entry under the type.
+    pub registration_burn: HoprBalance,
+    /// Amount burned when updating an entry under the type.
+    pub update_burn: HoprBalance,
+}
+
+/// Selector for entries in the on-chain service registry.
+///
+/// See [`ChainReadServiceOperations::stream_services`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub struct ServiceSelector {
+    /// Selects entries registered under the given service type.
+    pub service_type: Option<ServiceType>,
+    /// Selects entries offered by the given node.
+    pub node: Option<Address>,
+    /// Selects only entries whose node still has a Safe binding.
+    ///
+    /// An entry whose node has no binding (`nodeToSafe(node) == 0`) is orphaned: the registry
+    /// accepts writes for an entry only from the node's Safe, so an orphaned entry can never be
+    /// updated or removed again and must be treated as dead.
+    pub live_only: bool,
+}
+
+impl ServiceSelector {
+    /// Selects entries registered under the given service type.
+    #[must_use]
+    pub fn with_service_type(mut self, service_type: ServiceType) -> Self {
+        self.service_type = Some(service_type);
+        self
+    }
+
+    /// Selects entries offered by the given node.
+    #[must_use]
+    pub fn with_node(mut self, node: Address) -> Self {
+        self.node = Some(node);
+        self
+    }
+
+    /// Selects only entries whose node still has a Safe binding.
+    #[must_use]
+    pub fn with_live_only(mut self, live_only: bool) -> Self {
+        self.live_only = live_only;
+        self
+    }
+
+    /// Checks if the given [`entry`](ServiceEntry) satisfies the selector.
+    ///
+    /// Liveness cannot be read off the entry: [`ServiceEntry::safe`] records the Safe that
+    /// performed the last write, not the binding the node has now. The caller therefore supplies
+    /// it as `node_is_live`, which is `nodeToSafe(entry.node) != 0` on the node-Safe registry the
+    /// service registry points at. It is ignored unless [`ServiceSelector::live_only`] is set.
+    pub fn satisfies(&self, entry: &ServiceEntry, node_is_live: bool) -> bool {
+        if self.live_only && !node_is_live {
+            return false;
+        }
+
+        if let Some(service_type) = &self.service_type
+            && &entry.service_type != service_type
+        {
+            return false;
+        }
+
+        if let Some(node) = &self.node
+            && &entry.node != node
+        {
+            return false;
+        }
+
+        true
+    }
+}
+
+/// Chain operations that read the on-chain service registry.
+///
+/// Implementors resolve the node-Safe binding themselves and pass it to
+/// [`ServiceSelector::satisfies`], which is the single definition of the filter.
+#[async_trait::async_trait]
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait ChainReadServiceOperations {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Returns the registry entries matching the given [`ServiceSelector`].
+    fn stream_services<'a>(&'a self, selector: ServiceSelector) -> Result<BoxStream<'a, ServiceEntry>, Self::Error>;
+
+    /// Counts the registry entries matching the given [`ServiceSelector`].
+    ///
+    /// This is potentially done more effectively than counting the elements of
+    /// the stream returned by [`ChainReadServiceOperations::stream_services`].
+    async fn count_services(&self, selector: ServiceSelector) -> Result<usize, Self::Error>;
+
+    /// Returns the registry configuration of the given service type,
+    /// or `None` if no such type is registered.
+    async fn get_service_type_config(
+        &self,
+        service_type: ServiceType,
+    ) -> Result<Option<ServiceTypeConfig>, Self::Error>;
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::{Duration, UNIX_EPOCH};
+
+    use super::*;
+
+    fn node() -> Address {
+        Address::new(&[1u8; 20])
+    }
+
+    fn other_node() -> Address {
+        Address::new(&[2u8; 20])
+    }
+
+    fn service_entry(service_type: ServiceType, node: Address) -> anyhow::Result<ServiceEntry> {
+        let registered_at = UNIX_EPOCH + Duration::from_secs(1_700_000_000);
+        Ok(ServiceEntry::new(
+            service_type,
+            node,
+            Address::new(&[9u8; 20]),
+            ServiceMetadata::default(),
+            registered_at,
+            registered_at,
+        )?)
+    }
+
+    #[test]
+    fn default_service_selector_should_accept_live_and_dead_entries_alike() -> anyhow::Result<()> {
+        let entry = service_entry(ServiceType::GVPN_EXIT, node())?;
+
+        assert!(ServiceSelector::default().satisfies(&entry, true));
+        assert!(ServiceSelector::default().satisfies(&entry, false));
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_selector_should_filter_by_service_type() -> anyhow::Result<()> {
+        let entry = service_entry(ServiceType::GVPN_EXIT, node())?;
+        let other_type: ServiceType = "other".parse()?;
+
+        assert!(
+            ServiceSelector::default()
+                .with_service_type(ServiceType::GVPN_EXIT)
+                .satisfies(&entry, true)
+        );
+        assert!(
+            !ServiceSelector::default()
+                .with_service_type(other_type)
+                .satisfies(&entry, true)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_selector_should_filter_by_node() -> anyhow::Result<()> {
+        let entry = service_entry(ServiceType::GVPN_EXIT, node())?;
+
+        assert!(ServiceSelector::default().with_node(node()).satisfies(&entry, true));
+        assert!(
+            !ServiceSelector::default()
+                .with_node(other_node())
+                .satisfies(&entry, true)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_selector_live_only_should_drop_entries_whose_node_has_no_safe_binding() -> anyhow::Result<()> {
+        let entry = service_entry(ServiceType::GVPN_EXIT, node())?;
+
+        assert!(ServiceSelector::default().with_live_only(true).satisfies(&entry, true));
+        assert!(!ServiceSelector::default().with_live_only(true).satisfies(&entry, false));
+
+        Ok(())
+    }
+
+    #[test]
+    fn service_selector_builder_methods_should_compose() -> anyhow::Result<()> {
+        let selector = ServiceSelector::default()
+            .with_service_type(ServiceType::GVPN_EXIT)
+            .with_node(node())
+            .with_live_only(true);
+
+        assert_eq!(
+            selector,
+            ServiceSelector {
+                service_type: Some(ServiceType::GVPN_EXIT),
+                node: Some(node()),
+                live_only: true,
+            }
+        );
+
+        assert!(selector.satisfies(&service_entry(ServiceType::GVPN_EXIT, node())?, true));
+
+        // Every field of the composed selector must still reject on its own.
+        assert!(!selector.satisfies(&service_entry(ServiceType::GVPN_EXIT, node())?, false));
+        assert!(!selector.satisfies(&service_entry("other".parse()?, node())?, true));
+        assert!(!selector.satisfies(&service_entry(ServiceType::GVPN_EXIT, other_node())?, true));
+
+        Ok(())
+    }
+}

--- a/src/chain/services.rs
+++ b/src/chain/services.rs
@@ -1,6 +1,8 @@
-use futures::stream::BoxStream;
+use futures::{future::BoxFuture, stream::BoxStream};
 pub use hopr_types::internal::prelude::{ServiceEntry, ServiceMetadata, ServiceType};
 use hopr_types::primitive::prelude::{Address, HoprBalance};
+
+use crate::chain::ChainReceipt;
 
 /// Registry configuration of a single service type.
 ///
@@ -21,6 +23,20 @@ pub struct ServiceTypeConfig {
     pub registration_burn: HoprBalance,
     /// Amount burned when updating an entry under the type.
     pub update_burn: HoprBalance,
+}
+
+/// Registry-wide service configuration.
+///
+/// Unlike [`ServiceTypeConfig`], these values apply to the registry itself and have no service
+/// type key. Consumers must query them to learn the current state because the corresponding
+/// [`ChainEvent`](crate::chain::ChainEvent) variants report changes only after subscription.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ServiceRegistryConfig {
+    /// Amount burned when registering a new service type.
+    pub type_registration_fee: HoprBalance,
+    /// Node-Safe registry currently used to resolve authority over service entries.
+    pub node_safe_registry: Address,
 }
 
 /// Selector for entries in the on-chain service registry.
@@ -113,6 +129,42 @@ pub trait ChainReadServiceOperations {
         &self,
         service_type: ServiceType,
     ) -> Result<Option<ServiceTypeConfig>, Self::Error>;
+
+    /// Returns the current registry-wide configuration.
+    ///
+    /// This is also available independently of the snapshot-first registry subscription.
+    async fn get_service_registry_config(&self) -> Result<ServiceRegistryConfig, Self::Error>;
+}
+
+/// Operations through which a node advertises its own services.
+///
+/// Implementations submit a transaction whose effective on-chain caller is the Safe currently
+/// bound to the node. Paid writes atomically approve exactly the current burn and execute the
+/// registry call, so a concurrent fee increase fails instead of overcharging the Safe.
+#[async_trait::async_trait]
+#[auto_impl::auto_impl(&, Box, Arc)]
+pub trait ChainWriteServiceOperations {
+    type Error: std::error::Error + Send + Sync + 'static;
+
+    /// Registers this node under `service_type` with opaque service-specific `metadata`.
+    async fn register_service<'a>(
+        &'a self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+    ) -> Result<BoxFuture<'a, Result<ChainReceipt, Self::Error>>, Self::Error>;
+
+    /// Replaces this node's metadata under `service_type`.
+    async fn update_service<'a>(
+        &'a self,
+        service_type: ServiceType,
+        metadata: ServiceMetadata,
+    ) -> Result<BoxFuture<'a, Result<ChainReceipt, Self::Error>>, Self::Error>;
+
+    /// Removes this node's entry under `service_type`. Deregistration is always free.
+    async fn deregister_service<'a>(
+        &'a self,
+        service_type: ServiceType,
+    ) -> Result<BoxFuture<'a, Result<ChainReceipt, Self::Error>>, Self::Error>;
 }
 
 #[cfg(test)]

--- a/src/node/types.rs
+++ b/src/node/types.rs
@@ -181,12 +181,6 @@ pub enum TicketEvent {
 mod tests {
     use std::collections::HashSet;
 
-    use hopr_types::crypto::{
-        keypairs::Keypair,
-        prelude::{BjjKeypair, ChainKeypair},
-        types::PublicKey,
-    };
-
     use super::*;
 
     #[test]


### PR DESCRIPTION
- Adds the `ChainReadServiceOperations` trait, which reads service types and streams service
  registry entries, together with its selector and configuration types.
- Breaking change: `HoprChainApi` now requires the new trait, so every chain backend must
  implement it. Bumps the crate to 1.21.0.
- Removes an unused import from a test module.

## Depends on

- hoprnet/hopr-types#104 - this branch pins `hopr-types` to its git rev.

## Follow-up

- [ ] After hoprnet/hopr-types#104 merges and `hopr-types` 2.3.0 is published, replace the
      `git`/`rev` pin in `Cargo.toml` with `version = "2.3.0"`, then publish `hopr-api`
      1.21.0 for hopr-impls and hoprnet.
