### PR TITLE
feat(graph): accept SURB round-trip outcomes as edge telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.20.1"
+version = "2.0.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.20.1"
+version = "1.21.0"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"

--- a/src/graph/traits.rs
+++ b/src/graph/traits.rs
@@ -29,6 +29,23 @@ pub enum EdgeWeightType {
         /// Total number of acknowledgments received from the immediate peer.
         num_acks: u64,
     },
+    /// SURB round-trips expected across this edge over a reporting interval, and how many of them
+    /// were observed to complete.
+    ///
+    /// Deliberately not an [`EdgeTransportMeasurement`]: a round-trip proves the whole loop was
+    /// traversed but carries no per-edge latency, so recording it as a transport measurement would
+    /// mean inventing a duration and feeding it to the latency average — corrupting a figure that
+    /// is otherwise measured directly.
+    ///
+    /// Counts rather than single events, for the same reason
+    /// [`Self::ImmediateProtocolConformance`] carries counts: a SURB is minted far too often to
+    /// take a graph write lock per occurrence.
+    SurbRoundTrips {
+        /// SURBs minted across this edge during the interval.
+        expected: u64,
+        /// How many of them had their reply arrive.
+        observed: u64,
+    },
 }
 
 /// Trait for recording new observations onto a graph edge.
@@ -168,6 +185,17 @@ pub trait NetworkGraphView {
 
     /// Returns the self-identity node of this graph.
     fn identity(&self) -> &Self::NodeId;
+
+    /// Resolves a node to the slot it occupies in a [`PathId`], if the graph knows it.
+    ///
+    /// A [`PathId`] identifies a path by position rather than by key, so anything reporting a path
+    /// it did not obtain from [`simple_paths`](GraphPathSelection::simple_paths) -- notably SURB
+    /// round-trips, which know their route as public keys -- needs this to speak the same language.
+    ///
+    /// The mapping is only valid for as long as the node stays in the graph; a caller that holds an
+    /// id across a removal may find it refers to a different node, so ids are best resolved and
+    /// consumed promptly.
+    fn path_slot(&self, key: &Self::NodeId) -> Option<u64>;
 }
 
 /// A trait for mutating the graph topology.

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -1,4 +1,4 @@
-use hopr_types::crypto::types::OffchainPublicKey;
+use hopr_types::{crypto::types::OffchainPublicKey, internal::routing::PathId};
 
 /// Error observed during the measurements updating the graph edges.
 #[derive(thiserror::Error, Debug)]
@@ -53,6 +53,41 @@ pub struct EdgeCapacityUpdate {
     pub dest: OffchainPublicKey,
 }
 
+/// The two legs a SURB round-trip traverses.
+///
+/// A SURB rides a forward path to reach the replier and carries a return path for the reply to come
+/// back on, so one completed round-trip is evidence about **both** — which is why the pair is
+/// reported together rather than as two unrelated observations.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+pub struct ForwardAndReturnPath {
+    /// Path the SURB travelled to reach the replier.
+    pub forward: PathId,
+    /// Path encoded in the SURB for the reply to travel back on.
+    pub reply: PathId,
+}
+
+/// SURB round-trip outcomes over one reporting interval, as seen by the node that minted them.
+///
+/// Unlike a probe this costs no extra traffic — it is a by-product of data a session was sending
+/// anyway, so it accrues at data rates rather than at the probing interval. That is what lets a
+/// failed relay be noticed in seconds, instead of after an average has moved behind a path cache.
+///
+/// **Counts, not single events.** A round-trip is minted per SURB and a packet carries several, so
+/// reporting each one individually would take a graph write lock thousands of times a second on the
+/// packet hot path. Senders accumulate cheaply and report periodically, exactly as
+/// [`super::EdgeWeightType::ImmediateProtocolConformance`] does for packet/ack counts.
+#[derive(Debug, Copy, Clone)]
+pub struct SurbTelemetry {
+    /// The legs these round-trips traversed.
+    pub paths: ForwardAndReturnPath,
+    /// When the interval was reported, in milliseconds since epoch.
+    pub timestamp: u128,
+    /// SURBs minted over these paths during the interval.
+    pub expected: u64,
+    /// How many of them had their reply arrive.
+    pub observed: u64,
+}
+
 /// Edge measurements accepted for an edge in the graph.
 #[derive(Debug)]
 pub enum MeasurableEdge<N, P>
@@ -62,6 +97,8 @@ where
 {
     /// Probe outcome produced by cover-traffic or transport telemetry.
     Probe(std::result::Result<EdgeTransportTelemetry<N, P>, NetworkGraphError<P>>),
+    /// Outcome of a SURB round-trip, reported by the node that minted it.
+    Surb(SurbTelemetry),
     /// Capacity update for a specific directed edge.
     Capacity(Box<EdgeCapacityUpdate>),
     /// Connection-state change observed for a peer.


### PR DESCRIPTION
Lets the network graph be told about SURB round-trips, alongside the probe, capacity and connection-status observations it already accepts.

Probing is currently the only thing that tells the graph an n-hop path stopped working, and it is slow by construction: a success rate has to move behind a 60 s path cache before selection notices.

A SURB round-trip is evidence the graph already wants, produced by traffic a session was sending anyway — it costs no extra packets and accrues at data rates rather than at the probing interval.