### PR TITLE
chore: bump hopr-api to v1.21.0 and add support for additional deposit data

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -6,6 +6,7 @@ ignore = [
   "RUSTSEC-2026-0105", # 'core2' via 'multihash' [unmaintained], waiting on multiaddr update
   "RUSTSEC-2026-0173", # 'proc-macro-error2' via 'aquamarine' in 'hopr-types' [unmaintained], waiting on upstream update
   "RUSTSEC-2026-0249", # `smartstring` unmaintained, requires `opentelemetry-prometheus-text-exporter` > 0.3.0
+  "RUSTSEC-2026-0253", # `lru` unsound, needs alloy-provider update
 ]
 informational_warnings = ["unmaintained"]
 severity_threshold = "low"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "hopr-api"
-version = "1.20.1"
+version = "1.21.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hopr-api"
-version = "1.20.1"
+version = "1.21.0"
 description = "Common high-level external and internal API traits used by hopr-lib to implement the HOPR protocol"
 authors = ["HOPR Association <tech@hoprnet.org>"]
 homepage = "https://hoprnet.org/"

--- a/src/chain/deposit_pool.rs
+++ b/src/chain/deposit_pool.rs
@@ -14,8 +14,8 @@ pub type DepositNotification<'a, P, E> = BoxFuture<'a, Result<(P, HoprBalance), 
 /// The funds within this pool are represented by the given keypair `K`.
 ///
 /// The secret and public key of the keypair should be convertible to [`PixDepositSecret`] and [`PixDepositAddress`],
-/// respectively. The former is enforced by matching the [length of the keypair secret](Keypair::SecretLen) to the length
-/// of `PixDepositSecret` and the latter is enforced by the `Into<PixDepositAddress>` bound.
+/// respectively. The former is enforced by matching the [length of the keypair secret](Keypair::SecretLen) to the
+/// length of `PixDepositSecret` and the latter is enforced by the `Into<PixDepositAddress>` bound.
 ///
 /// The implementations can be completely non-anonymous (e.g., plain Ethereum transactions from
 /// node's Safe), or anonymous using a privacy pool in the background.

--- a/src/chain/deposit_pool.rs
+++ b/src/chain/deposit_pool.rs
@@ -14,7 +14,7 @@ pub type DepositNotification<'a, P, E> = BoxFuture<'a, Result<(P, HoprBalance), 
 /// The funds within this pool are represented by the given keypair `K`.
 ///
 /// The secret and public key of the keypair should be convertible to [`PixDepositSecret`] and [`PixDepositAddress`],
-/// respectively The former is enforced by matching the [length of the keypair secret](Keypair::SecretLen) to the length
+/// respectively. The former is enforced by matching the [length of the keypair secret](Keypair::SecretLen) to the length
 /// of `PixDepositSecret` and the latter is enforced by the `Into<PixDepositAddress>` bound.
 ///
 /// The implementations can be completely non-anonymous (e.g., plain Ethereum transactions from

--- a/src/node/types.rs
+++ b/src/node/types.rs
@@ -99,11 +99,14 @@ pub struct AnnouncedPeer {
     pub origin: AnnouncementOrigin,
 }
 
-/// Identifier for a Pix deposit address.
+/// Identifier for a PIX deposit address.
 pub type PixAddressId = (HoprPseudonym, NonZeroU32);
 
 /// Used to notify that the Exit has registered a sufficient deposit on a deposit address.
 pub type DepositUpdated = futures::channel::mpsc::Sender<(PixAddressId, HoprBalance)>;
+
+/// Additional data that is associated with a PIX deposit.
+pub type AdditionalDepositData = Box<[u8]>;
 
 /// Data for [`NewDepositAddress`](PixEvent) event.
 #[derive(Debug, Clone)]
@@ -114,6 +117,8 @@ pub struct PixNewDepositAddress {
     pub address: PixDepositAddress,
     /// The quota in bytes that corresponds to this deposit.
     pub quota: u64,
+    /// Optional additional untyped data associated with the deposit.
+    pub additional_data: Option<AdditionalDepositData>,
 }
 
 /// Data for [`DepositAddressReceived`](PixEvent) event.
@@ -125,6 +130,8 @@ pub struct PixDepositAddressReceived {
     pub address: PixDepositAddress,
     /// The quota in bytes that corresponds to this deposit.
     pub quota: u64,
+    /// Optional additional untyped data associated with the deposit.
+    pub additional_data: Option<AdditionalDepositData>,
     /// Sender of the [`DepositUpdated`] events.
     ///
     /// The [`DepositUpdated`] is optionally used to give future feedback that a deposit has
@@ -180,12 +187,6 @@ pub enum TicketEvent {
 #[cfg(test)]
 mod tests {
     use std::collections::HashSet;
-
-    use hopr_types::crypto::{
-        keypairs::Keypair,
-        prelude::{BjjKeypair, ChainKeypair},
-        types::PublicKey,
-    };
 
     use super::*;
 


### PR DESCRIPTION
Add arbitrary additional data to `PixNewDepositAddress` and `PixDepositAddressReceived`